### PR TITLE
Add wrapper for Dataset and rename summary to summarystats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Seth Axen <seth.axen@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 Pandas = "eadc2687-ae89-51f9-a5d9-86b5a6373a9c"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
@@ -19,10 +20,10 @@ Requires = "0.5.2"
 julia = "^1"
 
 [extras]
+CmdStan = "593b3428-ca2f-500c-ae53-031589ec8ddd"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-CmdStan = "593b3428-ca2f-500c-ae53-031589ec8ddd"
 
 [targets]
 test = ["CmdStan", "MCMCChains", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Pandas = "eadc2687-ae89-51f9-a5d9-86b5a6373a9c"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 NamedTupleTools = "0.11.0"
@@ -17,6 +18,7 @@ Pandas = "1.3.0"
 PyCall = "1.91.2"
 PyPlot = "2.8.2"
 Requires = "0.5.2"
+StatsBase = "0.32.0"
 julia = "^1"
 
 [extras]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,16 +28,16 @@
 
 ## [Stats](@id stats-api)
 
-| Name               | Description                                                                     |
-|:-------------------|:------------------------------------------------------------------------------- |
-| [`summary`](@ref)  | Create a data frame with summary statistics of an `InferenceData`.              |
-| [`hpd`](@ref)      | Calculate highest posterior density (HPD) of array for given credible_interval. |
-| [`loo`](@ref)      | Pareto-smoothed importance sampling leave-one-out (LOO) cross-validation.       |
-| [`loo_pit`](@ref)  | Compute leave-one-out probability integral transform (PIT) values.              |
-| [`psislw`](@ref)   | Pareto smoothed importance sampling (PSIS).                                     |
-| [`r2_score`](@ref) | $R^2$ for Bayesian regression models.                                           |
-| [`waic`](@ref)     | Calculate the widely available information criterion (WAIC).                    |
-| [`compare`](@ref)  | Compare models based on WAIC or LOO cross-validation.                           |
+| Name                | Description                                                                     |
+|:------------------- |:------------------------------------------------------------------------------- |
+| [`summarize`](@ref) | Compute summary statistics on an `InferenceData`                                |
+| [`hpd`](@ref)       | Calculate highest posterior density (HPD) of array for given credible_interval. |
+| [`loo`](@ref)       | Pareto-smoothed importance sampling leave-one-out (LOO) cross-validation.       |
+| [`loo_pit`](@ref)   | Compute leave-one-out probability integral transform (PIT) values.              |
+| [`psislw`](@ref)    | Pareto smoothed importance sampling (PSIS).                                     |
+| [`r2_score`](@ref)  | $R^2$ for Bayesian regression models.                                           |
+| [`waic`](@ref)      | Calculate the widely available information criterion (WAIC).                    |
+| [`compare`](@ref)   | Compare models based on WAIC or LOO cross-validation.                           |
 
 ## [Diagnostics](@id diagnostics-api)
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,16 +28,16 @@
 
 ## [Stats](@id stats-api)
 
-| Name                | Description                                                                     |
-|:------------------- |:------------------------------------------------------------------------------- |
-| [`summarize`](@ref) | Compute summary statistics on an `InferenceData`                                |
-| [`hpd`](@ref)       | Calculate highest posterior density (HPD) of array for given credible_interval. |
-| [`loo`](@ref)       | Pareto-smoothed importance sampling leave-one-out (LOO) cross-validation.       |
-| [`loo_pit`](@ref)   | Compute leave-one-out probability integral transform (PIT) values.              |
-| [`psislw`](@ref)    | Pareto smoothed importance sampling (PSIS).                                     |
-| [`r2_score`](@ref)  | $R^2$ for Bayesian regression models.                                           |
-| [`waic`](@ref)      | Calculate the widely available information criterion (WAIC).                    |
-| [`compare`](@ref)   | Compare models based on WAIC or LOO cross-validation.                           |
+| Name                     | Description                                                                     |
+|:------------------------ |:------------------------------------------------------------------------------- |
+| [`summarystats`](@ref)   | Compute summary statistics on an `InferenceData`                                |
+| [`hpd`](@ref)            | Calculate highest posterior density (HPD) of array for given credible_interval. |
+| [`loo`](@ref)            | Pareto-smoothed importance sampling leave-one-out (LOO) cross-validation.       |
+| [`loo_pit`](@ref)        | Compute leave-one-out probability integral transform (PIT) values.              |
+| [`psislw`](@ref)         | Pareto smoothed importance sampling (PSIS).                                     |
+| [`r2_score`](@ref)       | $R^2$ for Bayesian regression models.                                           |
+| [`waic`](@ref)           | Calculate the widely available information criterion (WAIC).                    |
+| [`compare`](@ref)        | Compare models based on WAIC or LOO cross-validation.                           |
 
 ## [Diagnostics](@id diagnostics-api)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -54,6 +54,9 @@ ArviZ.jl transparently interconverts between `arviz.InferenceData` and our own [
 
 Functions that in ArviZ return Pandas types here return their [Pandas.jl](https://github.com/JuliaPy/Pandas.jl) wrappers, which are used the same way.
 
+`arviz.summary` is here named [`summarize`](@ref) to avoid conflicting with `Base.summary`.
+For `InferenceData` inputs, [`Base.summary`](@ref) can be used like `arviz.summary`.
+
 ArviZ includes the context managers [`with_rc_context`](@ref) and [`with_interactive_backend`](@ref).
 ArviZ.jl includes functions that can be used with a nearly identical syntax.
 `with_interactive_backend` here is not limited to an IPython/IJulia context.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,13 +49,13 @@ In ArviZ.jl, most of the [same functions](@ref api) are exported and therefore c
 The exception are `from_xyz` converters for packages that have no (known) Julia wrappers.
 These functions are not exported to reduce namespace clutter.
 
+For `InferenceData` inputs, [`summarystats`](@ref) replaces `arviz.summary` to avoid confusion with `Base.summary`.
+For arbitrary inputs and the full functionality of `arviz.summary`, use [`ArviZ.summary`](@ref), which is not exported.
+
 ArviZ.jl transparently interconverts between `arviz.InferenceData` and our own [`InferenceData`](@ref), used for dispatch.
 `InferenceData` has identical usage to its Python counterpart.
 
 Functions that in ArviZ return Pandas types here return their [Pandas.jl](https://github.com/JuliaPy/Pandas.jl) wrappers, which are used the same way.
-
-`arviz.summary` is here named [`summarize`](@ref) to avoid conflicting with `Base.summary`.
-For `InferenceData` inputs, [`Base.summary`](@ref) can be used like `arviz.summary`.
 
 ArviZ includes the context managers [`with_rc_context`](@ref) and [`with_interactive_backend`](@ref).
 ArviZ.jl includes functions that can be used with a nearly identical syntax.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -140,7 +140,7 @@ savefig("quick_turingtrace.png"); nothing # hide
 We can also generate summary stats
 
 ```@example quickstart
-ArviZ.summarize(data)
+summarystats(data)
 ```
 
 and examine the energy distribution of the Hamiltonian sampler

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -140,7 +140,7 @@ savefig("quick_turingtrace.png"); nothing # hide
 We can also generate summary stats
 
 ```@example quickstart
-summarize(data)
+ArviZ.summarize(data)
 ```
 
 and examine the energy distribution of the Hamiltonian sampler

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -140,7 +140,7 @@ savefig("quick_turingtrace.png"); nothing # hide
 We can also generate summary stats
 
 ```@example quickstart
-summary(data)
+summarize(data)
 ```
 
 and examine the energy distribution of the Hamiltonian sampler

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -75,6 +75,7 @@ function __init__()
     copy!(xarray, pyimport_conda("xarray", "xarray", "conda-forge"))
     pyimport_conda("dask", "dask", "conda-forge")
 
+    pytype_mapping(xarray.Dataset, Dataset)
     pytype_mapping(arviz.InferenceData, InferenceData)
 
     @require MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d" begin

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -8,8 +8,10 @@ using PyPlot
 using Pandas
 using NamedTupleTools
 
-import Base: convert, propertynames, getproperty, hash, show, summary, +
+import Base: convert, propertynames, getproperty, hash, show, +
 import Base.Docs: getdoc
+import StatsBase
+import StatsBase: summarystats
 import Markdown: @doc_str
 import PyCall: PyObject
 
@@ -39,7 +41,7 @@ export plot_autocorr,
        plot_violin
 
 ## Stats
-export summarize, summary, compare, hpd, loo, loo_pit, psislw, r2_score, waic
+export summarystats, compare, hpd, loo, loo_pit, psislw, r2_score, waic
 
 ## Diagnostics
 export bfmi, geweke, ess, rhat, mcse

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -39,7 +39,7 @@ export plot_autocorr,
        plot_violin
 
 ## Stats
-export summary, compare, hpd, loo, loo_pit, psislw, r2_score, waic
+export summarize, summary, compare, hpd, loo, loo_pit, psislw, r2_score, waic
 
 ## Diagnostics
 export bfmi, geweke, ess, rhat, mcse

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -68,10 +68,11 @@ export with_rc_context
 import_arviz() = pyimport_conda("arviz", "arviz", "conda-forge")
 
 const arviz = import_arviz()
+const xarray = PyNULL()
 
 function __init__()
     copy!(arviz, import_arviz())
-    pyimport_conda("xarray", "xarray", "conda-forge")
+    copy!(xarray, pyimport_conda("xarray", "xarray", "conda-forge"))
     pyimport_conda("dask", "dask", "conda-forge")
 
     pytype_mapping(arviz.InferenceData, InferenceData)

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -10,6 +10,7 @@ using NamedTupleTools
 
 import Base: convert, propertynames, getproperty, hash, show, summary, +
 import Base.Docs: getdoc
+import Markdown: @doc_str
 import PyCall: PyObject
 
 # Exports

--- a/src/data.jl
+++ b/src/data.jl
@@ -47,14 +47,6 @@ function (data1::InferenceData + data2::InferenceData)
     return InferenceData(PyObject(data1) + PyObject(data2))
 end
 
-"""
-    summary(data::InferenceData; kwargs...)
-
-Compute summary statistics. See [`summarize`](@ref) for a description of the
-`kwargs`.
-"""
-Base.summary(data::InferenceData; kwargs...) = summarize(data; kwargs...)
-
 function Base.show(io::IO, data::InferenceData)
     out = pycall(pybuiltin("str"), String, data)
     out = replace(out, "Inference data" => "InferenceData")

--- a/src/data.jl
+++ b/src/data.jl
@@ -6,7 +6,7 @@ Loose wrapper around `arviz.InferenceData`, which is a container for inference
 data storage using xarray.
 
 `InferenceData` can be constructed either from an `arviz.InferenceData`
-or from multiple `Dataset`s assigned to groups specified as `kwargs`.
+or from multiple [`Dataset`](@ref)s assigned to groups specified as `kwargs`.
 
 Instead of directly creating an `InferenceData`, use the exported `from_xyz`
 functions or [`convert_to_inference_data`](@ref).

--- a/src/data.jl
+++ b/src/data.jl
@@ -47,6 +47,8 @@ function (data1::InferenceData + data2::InferenceData)
     return InferenceData(PyObject(data1) + PyObject(data2))
 end
 
+Base.summary(data::InferenceData; kwargs...) = summarize(data; kwargs...)
+
 function Base.show(io::IO, data::InferenceData)
     out = pycall(pybuiltin("str"), String, data)
     out = replace(out, r"Inference data" => "InferenceData")

--- a/src/data.jl
+++ b/src/data.jl
@@ -98,8 +98,7 @@ function _from_dict(
     return idata
 end
 
-@doc forwarddoc(:concat)
-function concat(args::InferenceData...; kwargs...)
+@doc forwarddoc(:concat) function concat(args::InferenceData...; kwargs...)
     ret = arviz.concat(args...; kwargs...)
     ret === nothing && return args[1]
     return ret

--- a/src/data.jl
+++ b/src/data.jl
@@ -47,6 +47,12 @@ function (data1::InferenceData + data2::InferenceData)
     return InferenceData(PyObject(data1) + PyObject(data2))
 end
 
+"""
+    summary(data::InferenceData; kwargs...)
+
+Compute summary statistics. See [`summarize`](@ref) for a description of the
+`kwargs`.
+"""
 Base.summary(data::InferenceData; kwargs...) = summarize(data; kwargs...)
 
 function Base.show(io::IO, data::InferenceData)

--- a/src/data.jl
+++ b/src/data.jl
@@ -63,6 +63,12 @@ end
 
 @forwardfun convert_to_inference_data
 
+function convert_to_dataset(data::InferenceData; group = :posterior, kwargs...)
+    group = Symbol(group)
+    dataset = getproperty(data, group)
+    return dataset
+end
+
 @forwardfun load_arviz_data
 
 @forwardfun to_netcdf

--- a/src/data.jl
+++ b/src/data.jl
@@ -57,7 +57,7 @@ Base.summary(data::InferenceData; kwargs...) = summarize(data; kwargs...)
 
 function Base.show(io::IO, data::InferenceData)
     out = pycall(pybuiltin("str"), String, data)
-    out = replace(out, r"Inference data" => "InferenceData")
+    out = replace(out, "Inference data" => "InferenceData")
     print(io, out)
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -6,7 +6,7 @@ Loose wrapper around `arviz.InferenceData`, which is a container for inference
 data storage using xarray.
 
 `InferenceData` can be constructed either from an `arviz.InferenceData`
-or from multiple `xarray.Dataset`s assigned to groups specified as `kwargs`.
+or from multiple `Dataset`s assigned to groups specified as `kwargs`.
 
 Instead of directly creating an `InferenceData`, use the exported `from_xyz`
 functions or [`convert_to_inference_data`](@ref).

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,13 +1,57 @@
+"""
+    Dataset(::PyObject)
+
+Loose wrapper around `xarray.Dataset`, mostly used for dispatch.
+
+To create a `Dataset`, use [`convert_to_dataset`](@ref).
+"""
+struct Dataset
+    o::PyObject
+
+    function Dataset(o::PyObject)
+        pyisinstance(
+            o,
+            xarray.Dataset,
+        ) || throw(ArgumentError("$o is not an `xarray.Dataset`."))
+        return new(o)
+    end
+end
+
+@inline Dataset(data::Dataset) = data
+
+@inline PyObject(data::Dataset) = getfield(data, :o)
+
+Base.convert(::Type{Dataset}, o::PyObject) = Dataset(o)
+
+Base.hash(data::Dataset) = hash(PyObject(data))
+
+Base.propertynames(data::Dataset) = propertynames(PyObject(data))
+
+function Base.getproperty(data::Dataset, name::Symbol)
+    o = PyObject(data)
+    name === :o && return o
+    return getproperty(o, name)
+end
+
+function Base.show(io::IO, data::Dataset)
+    out = pycall(pybuiltin("str"), String, data)
+    out = replace(out, "<xarray.Dataset>" => "Dataset")
+    print(io, out)
+end
+
 @forwardfun convert_to_dataset
+
+convert_to_dataset(data::Dataset; kwargs...) = data
+
 @forwardfun dict_to_dataset
 
 """
-    dataset_to_dict(ds::PyObject) -> Tuple{Dict{String,Array},NamedTuple}
+    dataset_to_dict(ds::Dataset) -> Tuple{Dict{String,Array},NamedTuple}
 
-Convert an `xarray.Dataset` to a dictionary of `Array`s. The function also
+Convert a `Dataset` to a dictionary of `Array`s. The function also
 returns keyword arguments to [`dict_to_dataset`](@ref).
 """
-function dataset_to_dict(ds::PyObject)
+function dataset_to_dict(ds::Dataset)
     ds_dict = ds.to_dict()
     data_vars = ds_dict["data_vars"]
     attrs = ds_dict["attrs"]

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -129,9 +129,9 @@ end
 chains_to_dict(::Nothing; kwargs...) = nothing
 
 """
-    convert_to_dataset(chns::AbstractChains; library = MCMCChains, kwargs...) -> PyObject
+    convert_to_dataset(chns::AbstractChains; library = MCMCChains, kwargs...) -> Dataset
 
-Convert the chains `obj` to an `xarray.Dataset`. `library` is the library that
+Convert the chains `obj` to a [`Dataset`](@ref). `library` is the library that
 created the chains. Remaining `kwargs` are forwarded to
 [`dict_to_dataset`](@ref).
 """
@@ -208,7 +208,7 @@ function from_mcmcchains(
     )
 
     group_dicts = Dict{Symbol,Dict}()
-    group_datasets = Dict{Symbol,PyObject}()
+    group_datasets = Dict{Symbol,Dataset}()
     rekey_fun = d -> rekey(d, stats_key_map)
 
     # Convert chains to dicts

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -1,4 +1,4 @@
-using .MCMCChains: AbstractChains, ChainDataFrame, sections
+import .MCMCChains: AbstractChains, ChainDataFrame, sections
 using .DataFrames
 
 export from_mcmcchains

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -94,7 +94,7 @@ Compute summary statistics.
 ```@example summarize
 using ArviZ
 data = load_arviz_data("centered_eight")
-summarize(data; var_names=["mu", "tau"])
+ArviZ.summarize(data; var_names=["mu", "tau"])
 ```
 
 Other statistics can be calculated by passing a list of functions or a
@@ -116,7 +116,7 @@ func_dict = Dict(
     "95%" => x -> percentile(x, 95),
 )
 
-summarize(data; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
+ArviZ.summarize(data; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
 ```
 """ function summarize(data; index_origin = 1, coords = nothing, dims = nothing, kwargs...)
     posterior = convert_to_dataset(data; group = "posterior", coords = coords, dims = dims)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -11,15 +11,15 @@ const sample_stats_types = Dict(
     "diverging" => Bool,
 )
 
-@doc forwarddoc(:compare)
-compare(args...; kwargs...) = arviz.compare(args...; kwargs...) |> Pandas.DataFrame
+@doc forwarddoc(:compare) compare(args...; kwargs...) =
+    arviz.compare(args...; kwargs...) |> Pandas.DataFrame
 
 Docs.getdoc(::typeof(compare)) = forwardgetdoc(:compare)
 
 @forwardfun hpd
 
-@doc forwarddoc(:loo)
-loo(args...; kwargs...) = arviz.loo(args...; kwargs...) |> Pandas.Series
+@doc forwarddoc(:loo) loo(args...; kwargs...) =
+    arviz.loo(args...; kwargs...) |> Pandas.Series
 
 Docs.getdoc(::typeof(loo)) = forwardgetdoc(:loo)
 
@@ -27,13 +27,13 @@ Docs.getdoc(::typeof(loo)) = forwardgetdoc(:loo)
 
 @forwardfun psislw
 
-@doc forwarddoc(:r2_score)
-r2_score(args...; kwargs...) = arviz.r2_score(args...; kwargs...) |> Pandas.Series
+@doc forwarddoc(:r2_score) r2_score(args...; kwargs...) =
+    arviz.r2_score(args...; kwargs...) |> Pandas.Series
 
 Docs.getdoc(::typeof(r2_score)) = forwardgetdoc(:r2_score)
 
-@doc forwarddoc(:waic)
-waic(args...; kwargs...) = arviz.waic(args...; kwargs...) |> Pandas.Series
+@doc forwarddoc(:waic) waic(args...; kwargs...) =
+    arviz.waic(args...; kwargs...) |> Pandas.Series
 
 Docs.getdoc(::typeof(waic)) = forwardgetdoc(:waic)
 
@@ -118,8 +118,7 @@ func_dict = Dict(
 
 summarize(data; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
 ```
-"""
-function summarize(data; index_origin = 1, coords = nothing, dims = nothing, kwargs...)
+""" function summarize(data; index_origin = 1, coords = nothing, dims = nothing, kwargs...)
     posterior = convert_to_dataset(data; group = "posterior", coords = coords, dims = dims)
     s = arviz.summary(posterior; index_origin = index_origin, kwargs...)
     pyisinstance(s, Pandas.pandas_raw.DataFrame) && return Pandas.DataFrame(s)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -114,7 +114,7 @@ func_dict = Dict(
     "95%" => x -> percentile(x, 95),
 )
 
-summarystats(data; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
+summarystats(idata; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
 ```
 """
 function StatsBase.summarystats(data::Dataset; index_origin = 1, kwargs...)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -37,5 +37,91 @@ waic(args...; kwargs...) = arviz.waic(args...; kwargs...) |> Pandas.Series
 
 Docs.getdoc(::typeof(waic)) = forwardgetdoc(:waic)
 
-@doc forwarddoc(:summary)
-Base.summary(data::InferenceData) = arviz.summary(data) |> Pandas.DataFrame
+@doc doc"""
+    summarize(data; kwargs...) -> Union{Pandas.DataFrame,PyObject}
+
+Compute summary statistics.
+
+# Arguments
+- `data::Any`: Any object that can be converted to an `InferenceData`.
+    See [`convert_to_dataset`](@ref).
+
+# Keywords
+- `var_names::Vector{String}=nothing`: Names of variables to include in summary
+- `include_circ::Bool=false`: Whether to include circular statistics
+- `fmt::String="wide"`: Return format is either `Pandas.DataFrame` ("wide", "long")
+      or `xarray.Dataset` ("xarray").
+- `round_to::Int=nothing`: Number of decimals used to round results.
+      Use `nothing` to return raw numbers.
+- `stat_funcs::Union{Dict{String,Function},Vector{Function}}=nothing`:
+      A vector of functions or a dict of functions with function names as keys
+      used to calculate statistics. By default, the mean, standard deviation,
+      simulation standard error, and highest posterior density intervals are
+      included.
+      The functions will be given one argument, the samples for a variable as an
+      array, The functions should operate on an array, returning a single
+      number. For example, `Statistics.mean`, or `Statistics.var` would both
+      work.
+- `extend::Bool=true`: If `true`, use the statistics returned by `stat_funcs` in
+      addition to, rather than in place of, the default statistics. This is only
+      meaningful when `stat_funcs` is not `nothing`.
+- `credible_interval::Real=0.94`: Credible interval to plot. This is only
+      meaningful when `stat_funcs` is `nothing`.
+- `order::String="C"`: If `fmt` is "wide", use either "C" or "F" unpacking order.
+- `index_origin::Int=1`: If `fmt` is "wide", select $n$-based indexing for
+      multivariate parameters.
+- `coords::Dict{String,Vector}=nothing`: Map from named dimension to named
+      indices to be used if `fmt` is "xarray"
+- `dims::Dict{String,Vector{String}}=nothing`: Map from variable name to names
+      of its dimensions to be used if `fmt` is "xarray"
+
+# Returns
+- `Union{Pandas.DataFrame,PyObject}`: Return type dicated by `fmt` argument.
+      Return value will contain summary statistics for each variable. Default
+      statistics are:
+    + `mean`
+    + `sd`
+    + `hpd_3%`
+    + `hpd_97%`
+    + `mcse_mean`
+    + `mcse_sd`
+    + `ess_bulk`
+    + `ess_tail`
+    + `r_hat` (only computed for traces with 2 or more chains)
+
+# Examples
+
+```@example summarize
+using ArviZ
+data = load_arviz_data("centered_eight")
+summarize(data; var_names=["mu", "tau"])
+```
+
+Other statistics can be calculated by passing a list of functions or a
+dictionary with key, function pairs:
+
+```@example summarize
+using StatsBase, Statistics
+function median_sd(x)
+    med = median(x)
+    sd = sqrt(mean((x .- med).^2))
+    return sd
+end
+
+func_dict = Dict(
+    "std" => x -> std(x; corrected = false),
+    "median_std" => median_sd,
+    "5%" => x -> percentile(x, 5),
+    "median" => median,
+    "95%" => x -> percentile(x, 95),
+)
+
+summarize(data; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
+```
+"""
+function summarize(data; index_origin = 1, coords = nothing, dims = nothing, kwargs...)
+    posterior = convert_to_dataset(data; group = "posterior", coords = coords, dims = dims)
+    s = arviz.summary(posterior; index_origin = index_origin, kwargs...)
+    pyisinstance(s, Pandas.pandas_raw.DataFrame) && return Pandas.DataFrame(s)
+    return s
+end

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -37,20 +37,22 @@ Docs.getdoc(::typeof(r2_score)) = forwardgetdoc(:r2_score)
 
 Docs.getdoc(::typeof(waic)) = forwardgetdoc(:waic)
 
-@doc doc"""
-    summarize(data; kwargs...) -> Union{Pandas.DataFrame,PyObject}
+"""
+    summarystats(data::Dataset; kwargs...) -> Union{Pandas.DataFrame,Dataset}
+    summarystats(data::InferenceData; group = :posterior kwargs...) -> Union{Pandas.DataFrame,Dataset}
 
-Compute summary statistics.
+Compute summary statistics on `data`.
 
 # Arguments
-- `data::Any`: Any object that can be converted to an `InferenceData`.
-    See [`convert_to_dataset`](@ref).
+- `data::Union{Dataset,InferenceData}`: The data on which to compute summary
+      statistics. If `data` is an [`InferenceData`](@ref), only the dataset
+      corresponding to `group` is used.
 
 # Keywords
 - `var_names::Vector{String}=nothing`: Names of variables to include in summary
 - `include_circ::Bool=false`: Whether to include circular statistics
 - `fmt::String="wide"`: Return format is either `Pandas.DataFrame` ("wide", "long")
-      or `xarray.Dataset` ("xarray").
+      or [`Dataset`](@ref) ("xarray").
 - `round_to::Int=nothing`: Number of decimals used to round results.
       Use `nothing` to return raw numbers.
 - `stat_funcs::Union{Dict{String,Function},Vector{Function}}=nothing`:
@@ -68,15 +70,11 @@ Compute summary statistics.
 - `credible_interval::Real=0.94`: Credible interval to plot. This is only
       meaningful when `stat_funcs` is `nothing`.
 - `order::String="C"`: If `fmt` is "wide", use either "C" or "F" unpacking order.
-- `index_origin::Int=1`: If `fmt` is "wide", select $n$-based indexing for
+- `index_origin::Int=1`: If `fmt` is "wide", select 𝑛-based indexing for
       multivariate parameters.
-- `coords::Dict{String,Vector}=nothing`: Map from named dimension to named
-      indices to be used if `fmt` is "xarray"
-- `dims::Dict{String,Vector{String}}=nothing`: Map from variable name to names
-      of its dimensions to be used if `fmt` is "xarray"
 
 # Returns
-- `Union{Pandas.DataFrame,PyObject}`: Return type dicated by `fmt` argument.
+- `Union{Pandas.DataFrame,Dataset}`: Return type dicated by `fmt` argument.
       Return value will contain summary statistics for each variable. Default
       statistics are:
     + `mean`
@@ -91,16 +89,16 @@ Compute summary statistics.
 
 # Examples
 
-```@example summarize
+```@example summarystats
 using ArviZ
-data = load_arviz_data("centered_eight")
-ArviZ.summarize(data; var_names=["mu", "tau"])
+idata = load_arviz_data("centered_eight")
+summarystats(idata; var_names=["mu", "tau"])
 ```
 
 Other statistics can be calculated by passing a list of functions or a
 dictionary with key, function pairs:
 
-```@example summarize
+```@example summarystats
 using StatsBase, Statistics
 function median_sd(x)
     med = median(x)
@@ -116,11 +114,40 @@ func_dict = Dict(
     "95%" => x -> percentile(x, 95),
 )
 
-ArviZ.summarize(data; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
+summarystats(data; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
 ```
-""" function summarize(data; index_origin = 1, coords = nothing, dims = nothing, kwargs...)
-    posterior = convert_to_dataset(data; group = "posterior", coords = coords, dims = dims)
-    s = arviz.summary(posterior; index_origin = index_origin, kwargs...)
-    pyisinstance(s, Pandas.pandas_raw.DataFrame) && return Pandas.DataFrame(s)
-    return s
+"""
+function StatsBase.summarystats(data::Dataset; index_origin = 1, kwargs...)
+    s = arviz.summary(data; index_origin = index_origin, kwargs...)
+    s isa Dataset && return s
+    return Pandas.DataFrame(s)
+end
+
+function StatsBase.summarystats(data::InferenceData; group = :posterior, kwargs...)
+    dataset = getproperty(data, Symbol(group))
+    return summarystats(dataset; kwargs...)
+end
+
+"""
+    summary(
+        data;
+        group = :posterior,
+        coords = nothing,
+        dims = nothing,
+        kwargs...,
+    ) -> Union{Pandas.DataFrame,PyObject}
+
+Compute summary statistics on any object that can be passed to
+[`convert_to_dataset`](@ref).
+
+# Keywords
+- `coords::Dict{String,Vector}=nothing`: Map from named dimension to named
+      indices.
+- `dims::Dict{String,Vector{String}}=nothing`: Map from variable name to names
+      of its dimensions.
+- `kwargs`: Keyword arguments passed to [`summarystats`](@ref).
+"""
+function summary(data; group = :posterior, coords = nothing, dims = nothing, kwargs...)
+    idata = convert_to_inference_data(data; group = group, coords = coords, dims = dims)
+    return summarystats(idata; group = group, kwargs...)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,7 +61,7 @@ end
 
 Get the list of customizable `rc` params using [`with_rc_context`](@ref).
 """
-rc_params() = Dict(k => v for (k,v) in ArviZ.arviz.rcParams)
+rc_params() = Dict(k => v for (k, v) in ArviZ.arviz.rcParams)
 
 """
     with_interactive_backend(f; backend::Symbol = nothing)
@@ -90,7 +90,8 @@ function with_interactive_backend(f; backend = nothing)
     pygui(oldgui)
 end
 
-forwarddoc(f::Symbol) = "See documentation for [`arviz.$(f)`](https://arviz-devs.github.io/arviz/generated/arviz.$(f).html)."
+forwarddoc(f::Symbol) =
+    "See documentation for [`arviz.$(f)`](https://arviz-devs.github.io/arviz/generated/arviz.$(f).html)."
 
 forwardgetdoc(f::Symbol) = Docs.getdoc(getproperty(arviz, f))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
 include("helpers.jl")
 include("test_dataset.jl")
 include("test_data.jl")
+include("test_stats.jl")
 include("test_mcmcchains.jl")

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -90,6 +90,23 @@ end
     end
 end
 
+@testset "ArviZ.convert_to_dataset(data::InferenceData; kwargs...)" begin
+    rng = MersenneTwister(42)
+    A = Dict("A" => randn(rng, 2, 10, 2))
+    B = Dict("B" => randn(rng, 2, 10, 2))
+    dataA = ArviZ.convert_to_dataset(A)
+    dataB = ArviZ.convert_to_dataset(B)
+    idata = InferenceData(posterior = dataA, prior = dataB)
+
+    ds1 = ArviZ.convert_to_dataset(idata)
+    @test ds1 isa ArviZ.Dataset
+    @test "A" ∈ [ds1.keys()...]
+
+    ds2 = ArviZ.convert_to_dataset(idata; group = :prior)
+    @test ds2 isa ArviZ.Dataset
+    @test "B" ∈ [ds2.keys()...]
+end
+
 @testset "from_dict" begin
     rng = MersenneTwister(42)
 

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -6,7 +6,7 @@
     ndraws = 500
     vars = Dict(
         "a" => randn(rng, nchains, ndraws),
-        "b" => randn(rng, nchains, ndraws, J, K)
+        "b" => randn(rng, nchains, ndraws, J, K),
     )
     coords = Dict("bi" => 1:J, "bj" => 1:K)
     dims = Dict("b" => ["bi", "bj"])

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -1,3 +1,27 @@
+@testset "ArviZ.Dataset" begin
+    data = load_arviz_data("centered_eight")
+    dataset = data.posterior
+    @test dataset isa ArviZ.Dataset
+
+    @testset "construction" begin
+        pydataset = PyObject(dataset)
+        @test ArviZ.Dataset(pydataset) isa ArviZ.Dataset
+        @test PyObject(ArviZ.Dataset(pydataset)) === pydataset
+        @test ArviZ.Dataset(dataset) === dataset
+    end
+
+    @testset "properties" begin
+        @test length(propertynames(dataset)) > 1
+    end
+
+    @testset "conversion" begin
+        @test pyisinstance(PyObject(dataset), ArviZ.xarray.Dataset)
+        dataset4 = convert(ArviZ.Dataset, PyObject(dataset))
+        @test dataset4 isa ArviZ.Dataset
+        @test PyObject(dataset4) === PyObject(dataset)
+    end
+end
+
 @testset "dict to dataset roundtrip" begin
     rng = MersenneTwister(42)
     J = 8
@@ -13,6 +37,7 @@
     attrs = Dict("mykey" => 5)
 
     ds = ArviZ.dict_to_dataset(vars; coords = coords, dims = dims, attrs = attrs)
+    @test ds isa ArviZ.Dataset
     vars2, kwargs = ArviZ.dataset_to_dict(ds)
     for (k, v) in vars
         @test k ∈ keys(vars2)

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -22,6 +22,13 @@
     end
 end
 
+@testset "ArviZ.convert_to_dataset(data::ArviZ.Dataset; kwargs...)" begin
+    data = load_arviz_data("centered_eight")
+    dataset = data.posterior
+    @test ArviZ.convert_to_dataset(dataset) isa ArviZ.Dataset
+    @test ArviZ.convert_to_dataset(dataset) === dataset
+end
+
 @testset "dict to dataset roundtrip" begin
     rng = MersenneTwister(42)
     J = 8

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -1,4 +1,4 @@
-using MCMCChains
+import MCMCChains
 using CmdStan
 
 const noncentered_schools_stan_model = """
@@ -38,7 +38,7 @@ function makechains(names, ndraws, nchains; seed = 42, internal_names = [])
     rng = MersenneTwister(seed)
     nvars = length(names)
     vals = randn(rng, ndraws, nvars, nchains)
-    chns = Chains(vals, names, Dict(:internals => internal_names))
+    chns = MCMCChains.Chains(vals, names, Dict(:internals => internal_names))
     return chns
 end
 
@@ -205,7 +205,7 @@ end
         vals = Array{Union{Float64,Missing},3}(vals)
         vals[1,1,1] = missing
         names = ["var$(i)" for i = 1:nvars]
-        chns = Chains(vals, names)
+        chns = MCMCChains.Chains(vals, names)
         @test Missing <: eltype(chns.value)
         idata = from_mcmcchains(chns)
         vdict = vardict(idata.posterior)
@@ -226,7 +226,7 @@ end
     end
 end
 
-@testset "convert_to_dataset(::Chains)" begin
+@testset "convert_to_dataset(::MCMCChains.Chains)" begin
     nvars, nchains, ndraws = 2, 4, 20
     chns = makechains(nvars, ndraws, nchains)
     ds = ArviZ.convert_to_dataset(chns)
@@ -234,7 +234,7 @@ end
     @test ds.__class__.__name__ == "Dataset"
 end
 
-@testset "convert_to_inference_data(::Chains)" begin
+@testset "convert_to_inference_data(::MCMCChains.Chains)" begin
     nvars, nchains, ndraws = 2, 4, 20
     chns = makechains(nvars, ndraws, nchains)
     idata = convert_to_inference_data(chns; group = :posterior)

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -230,8 +230,7 @@ end
     nvars, nchains, ndraws = 2, 4, 20
     chns = makechains(nvars, ndraws, nchains)
     ds = ArviZ.convert_to_dataset(chns)
-    @test ds isa PyObject
-    @test ds.__class__.__name__ == "Dataset"
+    @test ds isa ArviZ.Dataset
 end
 
 @testset "convert_to_inference_data(::MCMCChains.Chains)" begin

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -63,7 +63,7 @@ function cmdstan_noncentered_schools(data, draws, chains; proj_dir = pwd())
         num_warmup = draws,
         num_samples = draws,
     )
-    rc, chns, cnames = stan(stan_model, data, proj_dir)
+    rc, chns, cnames = stan(stan_model, data, proj_dir, summary = false)
     outfiles = []
     for i = 1:chains
         push!(outfiles, "$(proj_dir)/tmp/$(model_name)_samples_$(i).csv")

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -203,7 +203,7 @@ end
         nvars, nchains, ndraws = 2, 4, 20
         vals = randn(rng, ndraws, nvars, nchains)
         vals = Array{Union{Float64,Missing},3}(vals)
-        vals[1,1,1] = missing
+        vals[1, 1, 1] = missing
         names = ["var$(i)" for i = 1:nvars]
         chns = MCMCChains.Chains(vals, names)
         @test Missing <: eltype(chns.value)
@@ -266,7 +266,7 @@ if VERSION.minor > 0
             prior = output.chains,
             prior_predictive = prior_predictive,
             coords = coords,
-            dims = dims
+            dims = dims,
         )
         idata2 = from_cmdstan(
             output.files;
@@ -275,7 +275,7 @@ if VERSION.minor > 0
             prior = output.files,
             prior_predictive = prior_predictive,
             coords = coords,
-            dims = dims
+            dims = dims,
         )
         @testset "idata.$(group)" for group in Symbol.(idata2._groups)
             ds1 = getproperty(idata1, group)

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -1,0 +1,35 @@
+import Pandas
+
+@testset "summarize" begin
+    rng = MersenneTwister(42)
+    nchains, ndraws = 4, 10
+    idata = convert_to_inference_data(Dict(
+        "a" => randn(rng, nchains, ndraws),
+        "b" => randn(rng, nchains, ndraws, 3, 4),
+    ))
+
+    @test summarize(idata) isa Pandas.DataFrame
+    @test summarize(idata; fmt = "wide") isa Pandas.DataFrame
+    @test summarize(idata; fmt = "long") isa Pandas.DataFrame
+    s = summarize(idata)
+    @test "a" ∈ Pandas.index(s)
+    @test "b" ∉ Pandas.index(s)
+    @test "b[0,0]" ∉ Pandas.index(s)
+    @test "b[1,1]" ∈ Pandas.index(s)
+    @test "b[0,0]" ∈ Pandas.index(summarize(idata; index_origin = 0))
+
+    s2 = summarize(idata; fmt = "xarray")
+    @test s2 isa PyObject
+    @test s2.__class__.__name__ == "Dataset"
+end
+
+@testset "summary" begin
+    rng = MersenneTwister(42)
+    nchains, ndraws = 4, 10
+    idata = convert_to_inference_data(Dict(
+        "a" => randn(rng, nchains, ndraws),
+        "b" => randn(rng, nchains, ndraws, 3, 4),
+    ))
+
+    @test summary(idata) isa Pandas.DataFrame
+end

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -1,6 +1,6 @@
 import Pandas
 
-@testset "summarize" begin
+@testset "summarystats" begin
     rng = MersenneTwister(42)
     nchains, ndraws = 4, 10
     idata = convert_to_inference_data(Dict(
@@ -8,27 +8,27 @@ import Pandas
         "b" => randn(rng, nchains, ndraws, 3, 4),
     ))
 
-    @test summarize(idata) isa Pandas.DataFrame
-    @test summarize(idata; fmt = "wide") isa Pandas.DataFrame
-    @test summarize(idata; fmt = "long") isa Pandas.DataFrame
-    s = summarize(idata)
+    @test summarystats(idata) isa Pandas.DataFrame
+    @test summarystats(idata; fmt = "wide") isa Pandas.DataFrame
+    @test summarystats(idata; fmt = "long") isa Pandas.DataFrame
+    s = summarystats(idata)
     @test "a" ∈ Pandas.index(s)
     @test "b" ∉ Pandas.index(s)
     @test "b[0,0]" ∉ Pandas.index(s)
     @test "b[1,1]" ∈ Pandas.index(s)
-    @test "b[0,0]" ∈ Pandas.index(summarize(idata; index_origin = 0))
+    @test "b[0,0]" ∈ Pandas.index(summarystats(idata; index_origin = 0))
 
-    s2 = summarize(idata; fmt = "xarray")
+    s2 = summarystats(idata; fmt = "xarray")
     @test s2 isa ArviZ.Dataset
 end
 
-@testset "summary" begin
+@testset "ArviZ.summary" begin
     rng = MersenneTwister(42)
     nchains, ndraws = 4, 10
-    idata = convert_to_inference_data(Dict(
+    data = Dict(
         "a" => randn(rng, nchains, ndraws),
         "b" => randn(rng, nchains, ndraws, 3, 4),
-    ))
+    )
 
-    @test summary(idata) isa Pandas.DataFrame
+    @test ArviZ.summary(data) isa Pandas.DataFrame
 end

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -19,8 +19,7 @@ import Pandas
     @test "b[0,0]" ∈ Pandas.index(summarize(idata; index_origin = 0))
 
     s2 = summarize(idata; fmt = "xarray")
-    @test s2 isa PyObject
-    @test s2.__class__.__name__ == "Dataset"
+    @test s2 isa ArviZ.Dataset
 end
 
 @testset "summary" begin


### PR DESCRIPTION
This lets us properly document the method without overriding `Base.summary`'s docs. `Base.summary(::InferenceData; kwargs...)` still behaves the same way.