### PR TITLE
Improve conversion from Chains to InferenceData

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -217,7 +217,7 @@ Note that we're using the same [`from_cmdstan`](@ref) function used by ArviZ to 
 data = from_cmdstan(
     stan_chns;
     posterior_predictive = "y_hat",
-#     observed_data = Dict("y" => schools_dat["y"]), # hide
+    observed_data = Dict("y" => schools_dat["y"]),
     log_likelihood = "log_lik",
     coords = Dict("school" => schools),
     dims = Dict(

--- a/src/data.jl
+++ b/src/data.jl
@@ -96,23 +96,22 @@ function _from_dict(
     return idata
 end
 
-@doc forwarddoc(:concat) function concat(args::InferenceData...; kwargs...)
-    ret = arviz.concat(args...; kwargs...)
-    ret === nothing && return args[1]
-    return ret
+@doc forwarddoc(:concat) function concat(data::InferenceData...; kwargs...)
+    data = Iterators.filter(x -> !isempty(x), data)
+    return arviz.concat(data...; inplace = false, kwargs...)
 end
 
 Docs.getdoc(::typeof(concat)) = forwardgetdoc(:concat)
 
 """
-    concat!(data::InferenceData, args::InferenceData...; kwargs...) -> InferenceData
+    concat!(data1::InferenceData, data::InferenceData...; kwargs...) -> InferenceData
 
-In-place version of `concat`, where `data` is modified to contain the
+In-place version of `concat`, where `data1` is modified to contain the
 concatenation of `data` and `args`. See [`concat`](@ref) for a description of
 `kwargs`.
 """
-function concat!(data::InferenceData, args::InferenceData...; kwargs...)
-    kwargs = merge((; kwargs...), (; inplace = true))
-    concat(data, args...; kwargs...)
-    return data
+function concat!(data1::InferenceData, data::InferenceData...; kwargs...)
+    data = Iterators.filter(x -> !isempty(x), data)
+    arviz.concat(data1, data...; inplace = true, kwargs...)
+    return data1
 end

--- a/src/data.jl
+++ b/src/data.jl
@@ -72,6 +72,8 @@ Base.isempty(data::InferenceData) = isempty(groupnames(data))
 
 @forwardfun convert_to_inference_data
 
+convert_to_inference_data(::Nothing; kwargs...) = InferenceData()
+
 function convert_to_dataset(data::InferenceData; group = :posterior, kwargs...)
     group = Symbol(group)
     dataset = getproperty(data, group)

--- a/src/data.jl
+++ b/src/data.jl
@@ -86,13 +86,14 @@ function _from_dict(
 )
     dicts = (posterior = posterior, dicts...)
 
-    idata = InferenceData()
+    datasets = []
     for (name, dict) in pairs(dicts)
         (dict === nothing || isempty(dict)) && continue
         dataset = dict_to_dataset(dict; attrs = attrs, coords = coords, dims = dims)
-        concat!(idata, InferenceData(; (name => dataset,)...))
+        push!(datasets, name => dataset)
     end
 
+    idata = InferenceData(; datasets...)
     return idata
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -53,6 +53,23 @@ function Base.show(io::IO, data::InferenceData)
     print(io, out)
 end
 
+"""
+    groupnames(data::InferenceData) -> Vector{Symbol}
+
+Get the names of the groups (datasets) in `data`.
+"""
+groupnames(data::InferenceData) = Symbol.(PyObject(data)._groups)
+
+"""
+    groups(data::InferenceData) -> Dict{Symbol,Dataset}
+
+Get the groups in `data` as a dictionary mapping names to datasets.
+"""
+groups(data::InferenceData) =
+    Dict((name => getproperty(data, name) for name in groupnames(data)))
+
+Base.isempty(data::InferenceData) = isempty(groupnames(data))
+
 @forwardfun convert_to_inference_data
 
 function convert_to_dataset(data::InferenceData; group = :posterior, kwargs...)

--- a/src/data.jl
+++ b/src/data.jl
@@ -115,3 +115,5 @@ function concat!(data1::InferenceData, data::InferenceData...; kwargs...)
     arviz.concat(data1, data...; inplace = true, kwargs...)
     return data1
 end
+
+concat!(; kwargs...) = InferenceData()

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,9 +1,22 @@
 """
     Dataset(::PyObject)
+    Dataset(; data_vars = nothing, coords = nothing, attrs = nothing)
 
 Loose wrapper around `xarray.Dataset`, mostly used for dispatch.
 
-To create a `Dataset`, use [`convert_to_dataset`](@ref).
+# Keywords
+- `data_vars::Dict{String,Any}`: Dict mapping variable names to
+    + `Vector`: Data vector. Single dimension is named after variable.
+    + `Tuple{String,Vector}`: Dimension name and data vector.
+    + `Tuple{NTuple{N,String},Array{T,N}} where {N,T}`: Dimension names and
+        data array.
+- `coords::Dict{String,Any}`: Dict mapping dimension names to index names.
+    Possible arguments has same form as `data_vars`.
+- `attrs::Dict{String,Any}`: Global attributes to save on this dataset.
+
+In most cases, use [`convert_to_dataset`](@ref) or
+[`convert_to_constant_dataset`](@ref) or  to create a `Dataset` instead of
+directly using a constructor.
 """
 struct Dataset
     o::PyObject

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -17,6 +17,8 @@ struct Dataset
     end
 end
 
+Dataset(; kwargs...) = xarray.Dataset(; kwargs...)
+
 @inline Dataset(data::Dataset) = data
 
 @inline PyObject(data::Dataset) = getfield(data, :o)

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -154,21 +154,24 @@ allowed, so long as it can be passed to [`convert_to_inference_data`](@ref).
 - `posterior::AbstractChains`: Draws from the posterior
 
 # Keywords
-- `posterior_predictive=nothing`: Draws from the posterior predictive distribution
-     or name(s) of predictive variables in `posterior`
-- `prior::AbstractChains=nothing`: Draws from the prior
-- `prior_predictive=nothing`: Draws from the prior predictive distribution
+- `posterior_predictive::Any=nothing`: Draws from the posterior predictive
+     distribution or name(s) of predictive variables in `posterior`
+- `prior::Any=nothing`: Draws from the prior
+- `prior_predictive::Any=nothing`: Draws from the prior predictive distribution
      or name(s) of predictive variables in `prior`
-- `observed_data=nothing`: Data actually observed or name(s) of observed data
-     variables in `posterior`
-- `constant_data=nothing`: Data that are constant, not observed (e.g. metadata),
-     or name(s) of variables in posterior
-- `log_likelihood::String=nothing`: Name of variable in `posterior` with log likelihoods
+- `observed_data::Dict{String,Array}=nothing`: Observed data on which the
+     `posterior` is conditional. It should only contain data which is modeled as
+     a random variable. Keys are parameter names and values.
+- `constant_data::Dict{String,Array}=nothing`: Model constants, data included
+     in the model which is not modeled as a random variable. Keys are parameter
+     names and values.
+- `log_likelihood::String=nothing`: Name of variable in `posterior` with log
+     likelihoods
 - `library=MCMCChains`: Name of library that generated the chains
 - `coords::Dict{String,Vector}=nothing`: Map from named dimension to named
-    indices
+     indices
 - `dims::Dict{String,Vector{String}}=nothing`: Map from variable name to names
-    of its dimensions
+     of its dimensions
 
 # Returns
 - `InferenceData`: The data with groups corresponding to the provided data
@@ -303,5 +306,5 @@ end
 
 Call [`from_mcmcchains`](@ref) on output of `CmdStan`.
 """
-from_cmdstan(data::AbstractChains; kwargs...) =
-    from_mcmcchains(data; library = "CmdStan", kwargs...)
+from_cmdstan(posterior::AbstractChains; kwargs...) =
+    from_mcmcchains(posterior; library = "CmdStan", kwargs...)

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -129,18 +129,6 @@ end
 chains_to_dict(::Nothing; kwargs...) = nothing
 
 """
-    convert_to_dataset(chns::AbstractChains; library = MCMCChains, kwargs...) -> Dataset
-
-Convert the chains `obj` to a [`Dataset`](@ref). `library` is the library that
-created the chains. Remaining `kwargs` are forwarded to
-[`dict_to_dataset`](@ref).
-"""
-function convert_to_dataset(chns::AbstractChains; library = MCMCChains, kwargs...)
-    chns_dict = chains_to_dict(chns)
-    return dict_to_dataset(chns_dict; library = library, kwargs...)
-end
-
-"""
     convert_to_inference_data(obj::AbstractChains; group = :posterior, kwargs...) -> InferenceData
 
 Convert the chains `obj` to an [`InferenceData`](@ref) with the specified `group`.

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -25,23 +25,6 @@ const stan_key_map = Dict(
 const stats_key_map = merge(turing_key_map, stan_key_map)
 
 """
-    topandas(df::DataFrames.DataFrame) -> Pandas.DataFrame
-    topandas(df::MCMCChains.ChainDataFrame) -> Pandas.DataFrame
-
-Convert `df` into a Pandas format, maintaining column order and replacing
-`missing` with `NaN`.
-"""
-function topandas(df::DataFrames.DataFrame)
-    cols = replacemissing.(eachcol(df))
-    colnames = names(df)
-    df = DataFrames.DataFrame(cols, colnames)
-    pdf = Pandas.DataFrame(df)
-    return pdf[colnames]
-end
-
-topandas(df::ChainDataFrame) = topandas(df.df)
-
-"""
     reshape_values(x::AbstractArray) -> AbstractArray
 
 Convert from `MCMCChains` variable values with dimensions

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -137,6 +137,12 @@ end
 """
     from_mcmcchains(posterior::AbstractChains; kwargs...) -> InferenceData
     from_mcmcchains(; kwargs...) -> InferenceData
+    from_mcmcchains(
+        posterior::AbstractChains,
+        posterior_predictive::Any,
+        log_likelihood::String;
+        kwargs...
+    ) -> InferenceData
 
 Convert data in an `MCMCChains.AbstractChains` format into an
 [`InferenceData`](@ref).
@@ -168,27 +174,13 @@ allowed, so long as it can be passed to [`convert_to_inference_data`](@ref).
 - `InferenceData`: The data with groups corresponding to the provided data
 """
 function from_mcmcchains(
-    posterior = nothing;
-    prior = nothing,
-    posterior_predictive = nothing,
-    prior_predictive = nothing,
-    observed_data = nothing,
-    constant_data = nothing,
-    log_likelihood = nothing,
+    posterior,
+    posterior_predictive,
+    log_likelihood;
     library = MCMCChains,
     kwargs...,
 )
-    attrs = attributes_dict(posterior)
-    attrs = merge(attrs, Dict("inference_library" => string(library)))
-    kwargs = convert(Dict, merge((; attrs = attrs, dims = nothing), kwargs))
-    post_groups = (
-        posterior_predictive = posterior_predictive,
-        observed_data = observed_data,
-        constant_data = constant_data,
-    )
-
-    group_dicts = Dict{Symbol,Dict}()
-    group_datasets = Dict{Symbol,Dataset}()
+    kwargs = convert(Dict, merge((; dims = nothing), kwargs))
     rekey_fun = d -> rekey(d, stats_key_map)
 
     # Convert chains to dicts
@@ -196,22 +188,21 @@ function from_mcmcchains(
     stats_dict = chains_to_dict(posterior; section = :internals, rekey_fun = rekey_fun)
     stats_dict = enforce_stat_types(stats_dict)
 
-    prior_dict = chains_to_dict(prior)
-    prior_stats_dict = chains_to_dict(prior; section = :internals, rekey_fun = rekey_fun)
-    prior_stats_dict = enforce_stat_types(prior_stats_dict)
-
-    # Remove variables from posterior/prior or convert to dataset
-    for (group, data) in pairs(post_groups)
-        if typeof(data) <: Union{String,Vector{String}}
-            group_dicts[group] = popsubdict!(post_dict, data)
-        elseif data !== nothing
-            group_datasets[group] = convert_to_dataset(data; kwargs...)
+    if typeof(posterior_predictive) <: Union{String,Vector{String}}
+        post_pred_idata = InferenceData()
+        post_pred_dict = popsubdict!(post_dict, posterior_predictive)
+    else
+        if posterior_predictive !== nothing
+            post_pred_dataset = convert_to_dataset(
+                posterior_predictive;
+                library = library,
+                kwargs...,
+            )
+            post_pred_idata = InferenceData(posterior_predictive = post_pred_dataset)
+        else
+            post_pred_idata = InferenceData()
         end
-    end
-    if typeof(prior_predictive) <: Union{String,Vector{String}}
-        group_dicts[:prior_predictive] = popsubdict!(prior_dict, prior_predictive)
-    elseif prior_predictive !== nothing
-        group_datasets[:prior_predictive] = convert_to_dataset(prior_predictive; kwargs...)
+        post_pred_dict = nothing
     end
 
     # Handle log likelihood as a special case
@@ -229,18 +220,82 @@ function from_mcmcchains(
         end
     end
 
-    idata1 = _from_dict(
+    attrs = attributes_dict(posterior)
+    attrs = merge(attrs, Dict("inference_library" => string(library)))
+    kwargs = convert(Dict, merge((; attrs = attrs, dims = nothing), kwargs))
+    post_idata = _from_dict(
         post_dict;
         sample_stats = stats_dict,
-        prior = prior_dict,
-        sample_stats_prior = prior_stats_dict,
-        group_dicts...,
+        posterior_predictive = post_pred_dict,
         kwargs...,
     )
-    idata2 = InferenceData(; group_datasets...)
-    isempty(idata1._groups) && return idata2
-    isempty(idata2._groups) || concat!(idata1, idata2)
-    return idata1
+
+    idata = InferenceData(; groups(post_idata)..., groups(post_pred_idata)...)
+    return idata
+end
+
+function from_mcmcchains(
+    posterior = nothing;
+    prior = nothing,
+    posterior_predictive = nothing,
+    prior_predictive = nothing,
+    observed_data = nothing,
+    constant_data = nothing,
+    log_likelihood = nothing,
+    library = MCMCChains,
+    kwargs...,
+)
+    kwargs = convert(Dict, merge((; dims = nothing, coords = nothing), kwargs))
+
+    all_idata = InferenceData[]
+    post_idata = from_mcmcchains(
+        posterior,
+        posterior_predictive,
+        log_likelihood;
+        library = library,
+        kwargs...,
+    )
+    push!(all_idata, post_idata)
+
+    if prior !== nothing
+        pre_prior_idata = convert_to_inference_data(
+            prior;
+            posterior_predictive = prior_predictive,
+            library = library,
+            kwargs...,
+        )
+        prior_idata = rekey(
+            pre_prior_idata,
+            Dict(
+                :posterior => :prior,
+                :posterior_predictive => :prior_predictive,
+                :sample_stats => :sample_stats_prior,
+            ),
+        )
+        push!(all_idata, prior_idata)
+    end
+
+    if observed_data !== nothing
+        observed_idata = InferenceData(observed_data = convert_to_constant_dataset(
+            observed_data;
+            dims = kwargs[:dims],
+            coords = kwargs[:coords],
+        ))
+        push!(all_idata, observed_idata)
+    end
+
+    if constant_data !== nothing
+        constant_idata = InferenceData(constant_data = convert_to_constant_dataset(
+            constant_data;
+            dims = kwargs[:dims],
+            coords = kwargs[:coords],
+        ))
+        push!(all_idata, constant_idata)
+    end
+
+    all_groups = mapreduce(groups, merge, all_idata)
+    idata = InferenceData(; all_groups...)
+    return idata
 end
 
 """

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -76,14 +76,8 @@ function varnames_locs_dict(loc_names)
 end
 
 function attributes_dict(chns::AbstractChains)
-    info = chns.info
-    :hashedsummary in propertynames(info) || return info
-    chndfs = info.hashedsummary.x[2]
-    names = tuple(snakecase.(getproperty.(chndfs, :name))...)
-    dfs = tuple(topandas.(chndfs)...)
-    info = delete(info, :hashedsummary)
-    attrs = merge(info, (mcmcchains_summary = Dict(zip(names, dfs)),))
-    return Dict{String,Any}((string(k), v) for (k, v) in pairs(attrs))
+    info = delete(chns.info, :hashedsummary)
+    return Dict{String,Any}((string(k), v) for (k, v) in pairs(info))
 end
 
 attributes_dict(::Nothing) = Dict()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -145,6 +145,9 @@ popsubdict!(dict, key::String) = popsubdict!(dict, [key])
 
 snakecase(s) = replace(lowercase(s), " " => "_")
 
+@inline _asarray(x) = [x]
+@inline _asarray(x::AbstractArray) = x
+
 enforce_stat_types(dict) =
     Dict(k => get(sample_stats_types, k, eltype(v)).(v) for (k, v) in dict)
 enforce_stat_types(::Nothing) = nothing

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -20,6 +20,20 @@
         @test :prior ∉ propertynames(data3)
     end
 
+    @testset "groups" begin
+        data4 = InferenceData(posterior = data.posterior)
+        @test ArviZ.groupnames(data4) == [:posterior]
+        g = ArviZ.groups(data4)
+        @test g isa Dict
+        @test :posterior in keys(g)
+        @test hash(data4.posterior) === hash(g[:posterior])
+    end
+
+    @testset "isempty" begin
+        @test !isempty(data)
+        @test isempty(InferenceData())
+    end
+
     @testset "conversion" begin
         @test pyisinstance(PyObject(data), ArviZ.arviz.InferenceData)
         data4 = convert(InferenceData, PyObject(data))
@@ -71,6 +85,10 @@ end
         Dict(:posterior => ["A", "B"], :prior => ["C", "D"]),
         idata1,
     ) == []
+
+    idata3 = concat!()
+    @test idata3 isa InferenceData
+    @test isempty(idata3)
 end
 
 @testset "convert_to_inference_data" begin
@@ -87,6 +105,12 @@ end
         arr = randn(rng, 2, 10, 2)
         idata2 = convert_to_inference_data(arr)
         @test check_multiple_attrs(Dict(:posterior => ["x"]), idata2) == []
+    end
+
+    @testset "convert_to_inference_data(::Nothing)" begin
+        idata3 = convert_to_inference_data(nothing)
+        @test idata3 isa InferenceData
+        @test isempty(idata3)
     end
 end
 

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -220,9 +220,6 @@ end
         attrs = idata.posterior.attrs
         @test attrs isa Dict
         @test attrs["inference_library"] == "MyLib"
-        @test attrs["mcmcchains_summary"] isa Dict
-        mcmcchains_summary = idata.posterior.attrs["mcmcchains_summary"]
-        @test first(values(mcmcchains_summary)).__class__.__name__ == "DataFrame"
     end
 end
 

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -141,17 +141,16 @@ end
 
     @testset "complete" begin
         nchains, ndraws = 4, 20
+        nobs = 10
         posterior = prior = ["a[1]", "a[2]"]
         posterior_predictive = prior_predictive = ["ahat[1]", "ahat[2]"]
-        observed_data = ["xhat[1]", "xhat[2]"]
-        constant_data = ["x[1]", "x[2]"]
+        observed_data = Dict("xhat" => 1:nobs)
+        constant_data = Dict("x" => (1:nobs) .+ nobs)
         sample_stats = ["stat"]
         log_likelihood = "log_lik"
         post_names = [
             posterior
             posterior_predictive
-            observed_data
-            constant_data
             sample_stats
             log_likelihood
         ]
@@ -163,8 +162,8 @@ end
             posterior_predictive = "ahat",
             prior = chns2,
             prior_predictive = "ahat",
-            observed_data = "xhat",
-            constant_data = "x",
+            observed_data = observed_data,
+            constant_data = constant_data,
             log_likelihood = "log_lik",
         )
         for group in (
@@ -192,9 +191,9 @@ end
         @test "log_likelihood" ∈ keys(dimdict(idata.sample_stats))
         @test length(dimdict(idata.sample_stats_prior)) == 3
         @test "stat" ∈ keys(dimdict(idata.sample_stats_prior))
-        @test length(dimdict(idata.observed_data)) == 4
+        @test length(dimdict(idata.observed_data)) == 2
         @test "xhat" ∈ keys(dimdict(idata.observed_data))
-        @test length(dimdict(idata.constant_data)) == 4
+        @test length(dimdict(idata.constant_data)) == 2
         @test "x" ∈ keys(dimdict(idata.constant_data))
     end
 


### PR DESCRIPTION
This PR simplifies and streamlines conversion from `Chains` to `InferenceData`. It also fixes the handling of `observed_data` and `constant_data` following [the schema](https://arviz-devs.github.io/arviz/schema/schema.html), adds new functions for creating `Dataset`, removes `mcmcchains_summary` from `attributes` (it breaks serialization with netcdf), and handles `concat` more safely.