### PR TITLE
Set default indexing in ArviZ to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3-DEV"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -107,6 +107,11 @@ function __init__()
     pytype_mapping(xarray.Dataset, Dataset)
     pytype_mapping(arviz.InferenceData, InferenceData)
 
+    # use 1-based indexing by default within arviz
+    py"""
+    $(arviz).rcparams.rcParams["data.index_origin"] = 1
+    """
+
     @require MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca" begin
         import .MonteCarloMeasurements: AbstractParticles
         include("particles.jl")

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -107,11 +107,6 @@ function __init__()
     pytype_mapping(xarray.Dataset, Dataset)
     pytype_mapping(arviz.InferenceData, InferenceData)
 
-    # use 1-based indexing by default within arviz
-    py"""
-    $(arviz).rcparams.rcParams["data.index_origin"] = 1
-    """
-
     @require MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca" begin
         import .MonteCarloMeasurements: AbstractParticles
         include("particles.jl")

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -120,8 +120,8 @@ func_dict = Dict(
 summarystats(idata; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
 ```
 """
-function StatsBase.summarystats(data::Dataset; kwargs...)
-    s = arviz.summary(data; kwargs...)
+function StatsBase.summarystats(data::Dataset; index_origin = 1, kwargs...)
+    s = arviz.summary(data; index_origin = index_origin, kwargs...)
     s isa Dataset && return s
     return Pandas.DataFrame(s)
 end

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -120,8 +120,8 @@ func_dict = Dict(
 summarystats(idata; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
 ```
 """
-function StatsBase.summarystats(data::Dataset; index_origin = 1, kwargs...)
-    s = arviz.summary(data; index_origin = index_origin, kwargs...)
+function StatsBase.summarystats(data::Dataset; kwargs...)
+    s = arviz.summary(data; kwargs...)
     s isa Dataset && return s
     return Pandas.DataFrame(s)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using ArviZ
 using Test
 
 include("helpers.jl")
+include("test_rcparams.jl")
 include("test_backend.jl")
 include("test_dataset.jl")
 include("test_data.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using ArviZ
 using Test
 
 include("helpers.jl")
-include("test_rcparams.jl")
 include("test_backend.jl")
 include("test_dataset.jl")
 include("test_data.jl")

--- a/test/test_rcparams.jl
+++ b/test/test_rcparams.jl
@@ -1,3 +1,0 @@
-@testset "rcParams" begin
-    @test ArviZ.arviz.rcparams.rcParams["data.index_origin"] == 1
-end

--- a/test/test_rcparams.jl
+++ b/test/test_rcparams.jl
@@ -1,0 +1,3 @@
+@testset "rcParams" begin
+    @test ArviZ.arviz.rcparams.rcParams["data.index_origin"] == 1
+end


### PR DESCRIPTION
This PR sets the `data.index_origin` rcParam to 1. For the moment, all behavior remains unchanged, since only `summarystats` modified `index_origin`. However, once ArviZ uses `index_origin` everywhere (see https://github.com/arviz-devs/arviz/issues/984), this will make the plots more Julian.

Edit: using the rcParam will have to wait until #54, since only the next arviz release will do that.