### PR TITLE
Bump compat for DataFrames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 CmdStan = "5.2.3, 6.0"
 Conda = "1.0"
-DataFrames = "0.20"
+DataFrames = "0.20, 0.21"
 MCMCChains = "0.3.15, 0.4.2, 1.0, 2.0, 3.0"
 MonteCarloMeasurements = "0.6.4, 0.7, 0.8"
 NamedTupleTools = "0.11.0, 0.12, 0.13"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -51,8 +51,8 @@ import DataFrames
 
         s = summarystats(idata)
         @test s isa DataFrames.DataFrame
-        @test first(names(summarystats(idata))) == :variable
-        @test first(names(summarystats(idata; fmt = "wide"))) == :variable
+        @test string(first(names(summarystats(idata)))) == "variable"
+        @test string(first(names(summarystats(idata; fmt = "wide")))) == "variable"
         @test :variable in propertynames(summarystats(idata; fmt = "wide"))
         @test "a" ∈ s.variable
         @test "b" ∉ s.variable

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -62,7 +62,7 @@ import DataFrames
 
         s2 = summarystats(idata; fmt = "long")
         @test s2 isa DataFrames.DataFrame
-        @test first(names(s2)) == :statistic
+        @test string(first(names(s2))) == "statistic"
         @test "mean" ∈ s2.statistic
 
         s3 = summarystats(idata; fmt = "xarray")


### PR DESCRIPTION
Supersedes #72. Since DataFrames 0.21 moved to string representation of column names, we just needed to update a test that assumed `Symbol`s.