### PR TITLE
Fix test for printing InferenceData

### DIFF
--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -48,15 +48,9 @@ using MonteCarloMeasurements: Particles
     end
 
     @testset "show" begin
-        @test startswith(
-            sprint(show, data),
-            """InferenceData with groups:
-            \t> posterior
-            \t> posterior_predictive
-            \t> sample_stats
-            \t> prior
-            \t> observed_data""",
-        )
+        @test startswith(sprint(show, data), "InferenceData with groups:")
+        rest = split(PyObject(data).__str__(), '\n'; limit = 2)[2]
+        @test split(sprint(show, data), '\n'; limit = 2)[2] == rest
     end
 end
 

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -50,11 +50,12 @@ using MonteCarloMeasurements: Particles
     @testset "show" begin
         @test startswith(
             sprint(show, data),
-            """
-            InferenceData with groups:
-            	> posterior
-            	> sample_stats
-            	> posterior_predictive""",
+            """InferenceData with groups:
+            \t> posterior
+            \t> posterior_predictive
+            \t> sample_stats
+            \t> prior
+            \t> observed_data""",
         )
     end
 end


### PR DESCRIPTION
When printing `InferenceData`, ArviZ now uses tabs to indent and has a few extra groups. This just fixes our test.