### PR TITLE
Fix errors in CI and docs build

### DIFF
--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -33,7 +33,7 @@ jobs:
           tar -xzpf ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}.tar.gz -C ${{ env.CMDSTAN_PATH }}
           make -C ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}/ build
         shell: bash
-      - uses: julia-actions/julia-docdeploy@releases/v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           JULIA_CMDSTAN_HOME: ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}/ # required by CmdStan.jl
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/src/mpl_examples.md
+++ b/docs/src/mpl_examples.md
@@ -176,7 +176,7 @@ using ArviZ
 ArviZ.use_style("arviz-darkgrid")
 
 idata = load_arviz_data("radon")
-plot_ess(idata; var_names = ["sigma_y"], kind = "quantile", color = "C4")
+plot_ess(idata; var_names = ["sigma"], kind = "quantile", color = "C4")
 
 gcf()
 ```
@@ -377,9 +377,8 @@ using ArviZ
 ArviZ.use_style("arviz-darkgrid")
 
 idata = load_arviz_data("radon")
-log_like = transpose(idata.sample_stats.log_likelihood.sel(chain = 0).values)
-log_weights = psislw(-log_like)[1]
-plot_loo_pit(idata; y = "y_like", log_weights = log_weights, ecdf = true, color = "maroon")
+
+plot_loo_pit(idata; y = "y", ecdf = true, color = "maroon")
 
 gcf()
 ```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -18,7 +18,7 @@ ArviZ.jl is designed to be used with libraries like [CmdStan](https://github.com
 ```@example quickstart
 using Random
 
-rng = Random.MersenneTwister(42)
+rng = Random.MersenneTwister(37772)
 plot_posterior(randn(rng, 100_000));
 gcf()
 ```
@@ -91,7 +91,7 @@ end
 param_mod = turing_model(J, y, σ)
 sampler = NUTS(nwarmup, 0.8)
 
-rng = Random.MersenneTwister(5130)
+rng = Random.MersenneTwister(16653)
 turing_chns = sample(
     rng,
     param_mod,
@@ -207,7 +207,7 @@ stan_model = Stanmodel(
     num_warmup = nwarmup,
     num_samples = nsamples,
     output_format = :mcmcchains,
-    random = CmdStan.Random(8675309),
+    random = CmdStan.Random(28983),
 )
 _, stan_chns, _ = stan(stan_model, schools_dat, summary = false);
 Base.Filesystem.rm(stan_model.tmpdir; recursive = true, force = true); # hide

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -52,7 +52,7 @@ using PyCall, PyPlot
         f((x = arr1, y = arr2); var_names = ["x", "y"])
         close(gcf())
         ispynull(ArviZ.bokeh) || @testset "bokeh" begin
-            @test f([(x = arr1,), (x = arr2,)]; var_names = ["x"], backend = :bokeh) isa
+            @test f((x = arr1, y = arr2); var_names = ["x", "y"], backend = :bokeh) isa
                   ArviZ.BokehPlot
         end
     end


### PR DESCRIPTION
- point to the actual latest version of the julia-docdeploy action
- update maptlotlib examples to reflect changes in arviz's radon dataset in v0.10.0
- avoid hitting the bug in https://github.com/arviz-devs/arviz/issues/1401 in the test suite
- choose new values for all seeds in quickstart within [1,2^29]. Pick a value for Turing that doesn't result in chains completely stalling (this currently raises an error when calling `plot_trace` in arviz)