### PR TITLE
Add HTML repr for InferenceData

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/data.jl
+++ b/src/data.jl
@@ -55,6 +55,15 @@ function Base.show(io::IO, data::InferenceData)
     print(io, out)
     return nothing
 end
+function Base.show(io::IO, ::MIME"text/html", data::InferenceData)
+    obj = PyObject(data)
+    (:_repr_html_ in propertynames(obj)) || return show(io, data)
+    out = obj._repr_html_()
+    out = replace(out, r"arviz.InferenceData" => "ArviZ.InferenceData")
+    out = replace(out, r"(<|&lt;)?xarray.Dataset(>|&gt;)?" => "Dataset (xarray.Dataset)")
+    print(io, out)
+    return nothing
+end
 
 """
     groupnames(data::InferenceData) -> Vector{Symbol}

--- a/src/data.jl
+++ b/src/data.jl
@@ -59,7 +59,7 @@ function Base.show(io::IO, ::MIME"text/html", data::InferenceData)
     obj = PyObject(data)
     (:_repr_html_ in propertynames(obj)) || return show(io, data)
     out = obj._repr_html_()
-    out = replace(out, r"arviz.InferenceData" => "ArviZ.InferenceData")
+    out = replace(out, r"arviz.InferenceData" => "InferenceData")
     out = replace(out, r"(<|&lt;)?xarray.Dataset(>|&gt;)?" => "Dataset (xarray.Dataset)")
     print(io, out)
     return nothing

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -56,7 +56,7 @@ function Base.show(io::IO, data::Dataset)
     return nothing
 end
 function Base.show(io::IO, ::MIME"text/html", data::Dataset)
-    obj = data.o
+    obj = PyObject(data)
     (:_repr_html_ in propertynames(obj)) || return show(io, data)
     out = obj._repr_html_()
     out = replace(out, r"(<|&lt;)?xarray.Dataset(>|&gt;)?" => "Dataset (xarray.Dataset)")

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -59,7 +59,7 @@ function Base.show(io::IO, ::MIME"text/html", data::Dataset)
     obj = data.o
     (:_repr_html_ in propertynames(obj)) || return show(io, data)
     out = obj._repr_html_()
-    out = replace(out, r"<?xarray.Dataset>?" => "Dataset (xarray.Dataset)")
+    out = replace(out, r"(<|&lt;)?xarray.Dataset(>|&gt;)?" => "Dataset (xarray.Dataset)")
     print(io, out)
     return nothing
 end

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -48,11 +48,21 @@ using MonteCarloMeasurements: Particles
     end
 
     @testset "show" begin
-        @testset "$mimetype" for mimetype in ("plain", "html")
-            text = repr(MIME("text/$(mimetype)"), data)
+        @testset "plain" begin
+            text = sprint(show, data)
+            @test startswith(text, "InferenceData with groups:")
+            rest = split(PyObject(data).__str__(), '\n'; limit = 2)[2]
+            @test split(text, '\n'; limit = 2)[2] == rest
+        end
+
+        @testset "html" begin
+            text = repr(MIME("text/html"), data)
             @test text isa String
-            @test occursin("ArviZ.InferenceData", text)
+            @test !occursin("<xarray.Dataset>", text)
+            @test !occursin("&lt;xarray.Dataset&gt;", text)
+            @test !occursin("arviz.InferenceData", text)
             @test occursin("Dataset (xarray.Dataset)", text)
+            @test occursin("InferenceData", text)
         end
     end
 end

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -49,7 +49,7 @@ using MonteCarloMeasurements: Particles
 
     @testset "show" begin
         @testset "$mimetype" for mimetype in ("plain", "html")
-            text = repr(MIME("text/$(mimetype)"), dataset)
+            text = repr(MIME("text/$(mimetype)"), data)
             @test text isa String
             @test occursin("ArviZ.InferenceData", text)
             @test occursin("Dataset (xarray.Dataset)", text)

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -48,9 +48,12 @@ using MonteCarloMeasurements: Particles
     end
 
     @testset "show" begin
-        @test startswith(sprint(show, data), "InferenceData with groups:")
-        rest = split(PyObject(data).__str__(), '\n'; limit = 2)[2]
-        @test split(sprint(show, data), '\n'; limit = 2)[2] == rest
+        @testset "$mimetype" for mimetype in ("plain", "html")
+            text = repr(MIME("text/$(mimetype)"), dataset)
+            @test text isa String
+            @test occursin("ArviZ.InferenceData", text)
+            @test occursin("Dataset (xarray.Dataset)", text)
+        end
     end
 end
 

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -32,6 +32,8 @@
         @testset "$mimetype" for mimetype in ("plain", "html")
             text = repr(MIME("text/$(mimetype)"), dataset)
             @test text isa String
+            @test !occursin("<xarray.Dataset>", text)
+            @test !occursin("&lt;xarray.Dataset&gt;", text)
             @test occursin("Dataset (xarray.Dataset)", text)
         end
     end


### PR DESCRIPTION
This PR makes it so when an HTML repr is requested from `ArviZ.InferenceData`, it forwards to `arviz.InferenceData`'s html repr, with light processing.
It also makes sure character entities are supported for xarray's dataset repr.

Relates #79.