### PR TITLE
Update to non-deprecated method for Turing

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -13,4 +13,4 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 [compat]
 MCMCChains = "3.0, 4.0"
 Soss = "0.11, 0.12, 0.13, 0.14"
-Turing = "0.14.6"
+Turing = "0.14.9"

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -176,9 +176,9 @@ param_mod_predict = turing_model(J, similar(y, Missing), σ)
 prior_predictive = predict(param_mod_predict, prior)
 posterior_predictive = predict(param_mod_predict, turing_chns)
 ```
-And to extract the elementwise log-likelihoods, which is useful if you want to compute metrics such as [`loo`](@ref),
+And to extract the pointwise log-likelihoods, which is useful if you want to compute metrics such as [`loo`](@ref),
 ```@example quickstart
-loglikelihoods = Turing.elementwise_loglikelihoods(param_mod, turing_chns)
+loglikelihoods = Turing.pointwise_loglikelihoods(param_mod, turing_chns)
 ```
 This can then be included in the [`from_mcmcchains`](@ref) call from above:
 ```@example quickstart


### PR DESCRIPTION
We realized `pointwise_loglikelihoods` made more sense than `elementwise_loglikelihoods`, so we've added `pointwise_loglikelihoods` and deprecated `elementwise_loglikelihoods` in Turing (https://github.com/TuringLang/Turing.jl/pull/1438). This PR makes the necessary change in the quickstart doc.