### PR TITLE
Make installing and updating dependencies more user-friendly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.4.5"
+version = "0.4.6"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
 using Documenter, ArviZ
-using MCMCChains # make `from_mcmcchains` available for API docs
+using MCMCChains: MCMCChains # make `from_mcmcchains` available for API docs
 
 makedocs(
     modules = [ArviZ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter, ArviZ
+using MCMCChains # make `from_mcmcchains` available for API docs
 
 makedocs(
     modules = [ArviZ],

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -8,10 +8,7 @@ using NamedTupleTools
 using DataFrames
 
 using PyCall
-if PyCall.conda
-    using Conda
-    Conda.add_channel("conda-forge") # try to avoid mixing channels
-end
+using Conda
 using PyPlot
 
 import Base:

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -93,7 +93,7 @@ include("setup.jl")
 
 # Load ArviZ once at precompilation time for docstringS
 copy!(arviz, import_arviz())
-check_arviz_version()
+check_needs_update(update = false)
 const _precompile_arviz_version = arviz_version()
 
 function __init__()

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -93,7 +93,7 @@ include("setup.jl")
 
 # Load ArviZ once at precompilation time for docstringS
 copy!(arviz, import_arviz())
-check_version()
+check_arviz_version()
 const _precompile_arviz_version = arviz_version()
 
 function __init__()

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -92,64 +92,12 @@ const pandas = PyNULL()
 const _rcParams = PyNULL()
 const _min_arviz_version = v"0.8.0"
 
-import_arviz() = pyimport_conda("arviz", "arviz", "conda-forge")
-
-arviz_version() = VersionNumber(arviz.__version__)
-
-function check_version()
-    if arviz_version() < _min_arviz_version
-        @warn "ArviZ.jl only officially supports arviz version $(_min_arviz_version) or greater but found version $(arviz_version()). Please update."
-    end
-    return nothing
-end
+include("setup.jl")
 
 # Load ArviZ once at precompilation time for docstringS
 copy!(arviz, import_arviz())
 check_version()
 const _precompile_arviz_version = arviz_version()
-
-function initialize_arviz()
-    ispynull(arviz) || return
-    copy!(arviz, import_arviz())
-    if arviz_version() != _precompile_arviz_version
-        @warn "ArviZ.jl was precompiled using arviz version $(_precompile_version) but loaded with version $(arviz_version()). Please recompile with `using Pkg; Pkg.build('ArviZ')`."
-    end
-
-    pytype_mapping(arviz.InferenceData, InferenceData)
-
-    # pytypemap-ing RcParams produces a Dict
-    copy!(_rcParams, py"$(arviz).rcparams.rcParams"o)
-
-    # use 1-based indexing by default within arviz
-    rcParams["data.index_origin"] = 1
-
-    # handle Bokeh showing ourselves
-    rcParams["plot.bokeh.show"] = false
-
-    initialize_xarray()
-    initialize_numpy()
-    return nothing
-end
-
-function initialize_xarray()
-    ispynull(xarray) || return
-    copy!(xarray, pyimport_conda("xarray", "xarray", "conda-forge"))
-    pyimport_conda("dask", "dask", "conda-forge")
-    pytype_mapping(xarray.Dataset, Dataset)
-    return nothing
-end
-
-function initialize_numpy()
-    # Trigger NumPy initialization, see https://github.com/JuliaPy/PyCall.jl/issues/744
-    PyObject([true])
-    return nothing
-end
-
-function initialize_pandas()
-    ispynull(pandas) || return
-    copy!(pandas, pyimport_conda("pandas", "pandas", "conda-forge"))
-    return nothing
-end
 
 function __init__()
     initialize_arviz()

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -85,12 +85,12 @@ export with_interactive_backend
 ## rcParams
 export rcParams, with_rc_context
 
+const _min_arviz_version = v"0.8.0"
 const arviz = PyNULL()
 const xarray = PyNULL()
 const bokeh = PyNULL()
 const pandas = PyNULL()
 const _rcParams = PyNULL()
-const _min_arviz_version = v"0.8.0"
 
 include("setup.jl")
 

--- a/src/bokeh.jl
+++ b/src/bokeh.jl
@@ -3,7 +3,7 @@ const has_bokeh_png_deps = false
 function initialize_bokeh()
     ispynull(bokeh) || return
     try
-        copy!(bokeh, pyimport_conda("bokeh", "bokeh", "conda-forge"))
+        copy!(bokeh, _import_dependency("bokeh", "bokeh"; channel = "conda-forge"))
     catch err
         copy!(bokeh, PyNULL())
         throw(err)
@@ -15,7 +15,7 @@ end
 function initialize_bokeh_png_deps()
     has_bokeh_png_deps && return
     try
-        pyimport_conda("selenium", "selenium", "conda-forge")
+        _import_dependency("selenium", "selenium"; channel = "conda-forge")
         has_bokeh_png_deps = true
     catch err
         has_bokeh_png_deps = false

--- a/src/data.jl
+++ b/src/data.jl
@@ -1,4 +1,4 @@
-const SUPPORTED_GROUPS = map(Symbol, arviz.data.inference_data.SUPPORTED_GROUPS)
+const SUPPORTED_GROUPS = Symbol[]
 
 """
     InferenceData(::PyObject)

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -108,13 +108,13 @@ function _import_dependency(modulename, pkgname; channel = nothing)
     return if _using_conda()
         # auto-installing with conda is safe and convenient
         if channel === nothing
-            pyimport_conda(modulename, pkgname_version)
+            pyimport_conda(modulename, pkgname)
         else
-            pyimport_conda(modulename, pkgname_version, channel)
+            pyimport_conda(modulename, pkgname, channel)
         end
     elseif _has_pip() && _isyes(Base.prompt("Try installing $pkgname using pip? [Y/n]"))
         # installing with pip is riskier, so we ask for permission
-        run(`$(PyCall.pyprogramname) -m pip install -- $pkgname_version`)
+        run(`$(PyCall.pyprogramname) -m pip install -- $pkgname`)
         pyimport(modulename)
     else
         error("Dependency $modulename cannot be imported. Install manually to continue.")

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,0 +1,53 @@
+import_arviz() = pyimport_conda("arviz", "arviz", "conda-forge")
+
+arviz_version() = VersionNumber(arviz.__version__)
+
+function check_version()
+    if arviz_version() < _min_arviz_version
+        @warn "ArviZ.jl only officially supports arviz version $(_min_arviz_version) or greater but found version $(arviz_version()). Please update."
+    end
+    return nothing
+end
+
+function initialize_arviz()
+    ispynull(arviz) || return
+    copy!(arviz, import_arviz())
+    if arviz_version() != _precompile_arviz_version
+        @warn "ArviZ.jl was precompiled using arviz version $(_precompile_version) but loaded with version $(arviz_version()). Please recompile with `using Pkg; Pkg.build('ArviZ')`."
+    end
+
+    pytype_mapping(arviz.InferenceData, InferenceData)
+
+    # pytypemap-ing RcParams produces a Dict
+    copy!(_rcParams, py"$(arviz).rcparams.rcParams"o)
+
+    # use 1-based indexing by default within arviz
+    rcParams["data.index_origin"] = 1
+
+    # handle Bokeh showing ourselves
+    rcParams["plot.bokeh.show"] = false
+
+    initialize_xarray()
+    initialize_numpy()
+    return nothing
+end
+
+function initialize_xarray()
+    ispynull(xarray) || return
+    copy!(xarray, pyimport_conda("xarray", "xarray", "conda-forge"))
+    pyimport_conda("dask", "dask", "conda-forge")
+    pytype_mapping(xarray.Dataset, Dataset)
+    return nothing
+end
+
+function initialize_numpy()
+    # Trigger NumPy initialization, see https://github.com/JuliaPy/PyCall.jl/issues/744
+    PyObject([true])
+    return nothing
+end
+
+function initialize_pandas()
+    ispynull(pandas) || return
+    copy!(pandas, pyimport_conda("pandas", "pandas", "conda-forge"))
+    return nothing
+end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -2,7 +2,7 @@ import_arviz() = pyimport_conda("arviz", "arviz", "conda-forge")
 
 arviz_version() = VersionNumber(arviz.__version__)
 
-function check_version()
+function check_arviz_version()
     if arviz_version() < _min_arviz_version
         @warn "ArviZ.jl only officially supports arviz version $(_min_arviz_version) or greater but found version $(arviz_version()). Please update."
     end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,4 +1,4 @@
-import_arviz() = pyimport_conda("arviz", "arviz", "conda-forge")
+import_arviz() = _import_dependency("arviz", "arviz"; channel = "conda-forge")
 
 arviz_version() = VersionNumber(arviz.__version__)
 
@@ -62,8 +62,8 @@ end
 
 function initialize_xarray()
     ispynull(xarray) || return
-    copy!(xarray, pyimport_conda("xarray", "xarray", "conda-forge"))
-    pyimport_conda("dask", "dask", "conda-forge")
+    copy!(xarray, _import_dependency("xarray", "xarray"; channel = "conda-forge"))
+    _import_dependency("dask", "dask"; channel = "conda-forge")
     pytype_mapping(xarray.Dataset, Dataset)
     return nothing
 end
@@ -76,7 +76,7 @@ end
 
 function initialize_pandas()
     ispynull(pandas) || return
-    copy!(pandas, pyimport_conda("pandas", "pandas", "conda-forge"))
+    copy!(pandas, _import_dependency("pandas", "pandas"; channel = "conda-forge"))
     return nothing
 end
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -44,6 +44,8 @@ function initialize_arviz()
     check_needs_update(update = true)
     check_needs_rebuild()
 
+    append!(SUPPORTED_GROUPS, map(Symbol, arviz.data.inference_data.SUPPORTED_GROUPS))
+
     pytype_mapping(arviz.InferenceData, InferenceData)
 
     # pytypemap-ing RcParams produces a Dict

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -6,6 +6,22 @@ function check_needs_update(; update = true)
     if arviz_version() < _min_arviz_version
         @warn "ArviZ.jl only officially supports arviz version $(_min_arviz_version) or " *
               "greater but found version $(arviz_version())."
+        if update
+            if update_arviz()
+                # yay, but we still already imported the old version
+                msg = """
+                Please rebuild ArviZ.jl with `using Pkg; Pkg.build("ArviZ")` and re-launch Julia
+                to continue.
+                """
+            else
+                msg = """
+                Could not automatically update arviz. Please manually update arviz, rebuild
+                ArviZ.jl with `using Pkg; Pkg.build("ArviZ")`, and then re-launch Julia to
+                continue.
+                """
+            end
+            @warn msg
+        end
     end
     return nothing
 end
@@ -63,3 +79,52 @@ function initialize_pandas()
     copy!(pandas, pyimport_conda("pandas", "pandas", "conda-forge"))
     return nothing
 end
+
+function update_arviz()
+    # updating arviz can change other packages, so we always ask for permission
+    if _using_conda() && _isyes(Base.prompt("Try updating arviz using conda? [Y/n]"))
+        # this syntax isn't officially supported, but it works (for now)
+        try
+            Conda.add("arviz>=$_min_arviz_version"; channel = "conda-forge")
+            return true
+        catch e
+            println(e.msg)
+        end
+    end
+    if _has_pip() && _isyes(Base.prompt("Try updating arviz using pip? [Y/n]"))
+        # can't specify version lower bound, so update to latest
+        try
+            run(`$(PyCall.pyprogramname) -m pip install --upgrade -- arviz`)
+            return true
+        catch e
+            println(e.msg)
+        end
+    end
+    return false
+end
+
+function _import_dependency(modulename, pkgname; channel = nothing)
+    _has_pymodule(modulename) && return pyimport(modulename)
+    return if _using_conda()
+        # auto-installing with conda is safe and convenient
+        if channel === nothing
+            pyimport_conda(modulename, pkgname_version)
+        else
+            pyimport_conda(modulename, pkgname_version, channel)
+        end
+    elseif _has_pip() && _isyes(Base.prompt("Try installing $pkgname using pip? [Y/n]"))
+        # installing with pip is riskier, so we ask for permission
+        run(`$(PyCall.pyprogramname) -m pip install -- $pkgname_version`)
+        pyimport(modulename)
+    else
+        error("Dependency $modulename cannot be imported. Install manually to continue.")
+    end
+end
+
+_isyes(s) = isempty(s) || lowercase(strip(s)) ∈ ("y", "yes")
+
+_using_conda() = PyCall.conda
+
+_has_pip() = ispynull(pyimport_e("pip"))
+
+_has_pymodule(modulename) = !ispynull(pyimport_e(modulename))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,7 +74,7 @@ convert_result(f, result, args...) = result
 load_backend(backend) = nothing
 
 function forwarddoc(f::Symbol)
-    return "See documentation for [`arviz.$(f)`](https://arviz-devs.github.io/arviz/generated/arviz.$(f).html)."
+    return "See documentation for [`arviz.$(f)`](https://arviz-devs.github.io/arviz/api/generated/arviz.$(f).html)."
 end
 
 forwardgetdoc(f::Symbol) = Docs.getdoc(getproperty(arviz, f))


### PR DESCRIPTION
This PR makes a number of changes to make installing and updating dependencies more user-friendly. In particular, when loading ArviZ, if arviz is available but too old, it prompts for updating using conda or pip. Also, if the available arviz version is out-of-sync with the version that was used to build ArviZ, then it prompts to rebuild ArviZ. If a dependency is unavailable, then it auto-installs if the user is using conda, else it prompts to install with pip if available.

Along the way it fixes the URL to arviz docs and does some code reorganization.