### PR TITLE
Fixes to auto-installation using pip

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -65,6 +65,7 @@ end
 function initialize_xarray()
     ispynull(xarray) || return
     copy!(xarray, _import_dependency("xarray", "xarray"; channel = "conda-forge"))
+    _import_dependency("dask", "dask"; channel = "conda-forge")
     pytype_mapping(xarray.Dataset, Dataset)
     return nothing
 end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -65,7 +65,6 @@ end
 function initialize_xarray()
     ispynull(xarray) || return
     copy!(xarray, _import_dependency("xarray", "xarray"; channel = "conda-forge"))
-    _import_dependency("dask", "dask"; channel = "conda-forge")
     pytype_mapping(xarray.Dataset, Dataset)
     return nothing
 end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -96,7 +96,7 @@ function update_arviz()
     if _has_pip() && _isyes(Base.prompt("Try updating arviz using pip? [Y/n]"))
         # can't specify version lower bound, so update to latest
         try
-            run(`$(PyCall.pyprogramname) -m pip install --upgrade -- arviz`)
+            run(PyCall.python_cmd(`-m pip install --upgrade -- arviz`))
             return true
         catch e
             println(e.msg)

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -127,6 +127,6 @@ _isyes(s) = isempty(s) || lowercase(strip(s)) ∈ ("y", "yes")
 
 _using_conda() = PyCall.conda
 
-_has_pip() = ispynull(pyimport_e("pip"))
+_has_pip() = _has_pymodule("pip")
 
 _has_pymodule(modulename) = !ispynull(pyimport_e(modulename))


### PR DESCRIPTION
Follow-up to #94. Prompting the user to install pip doesn't currently work during precompilation, so we instead fail with PyCall's nice error message. There were also some issues with the call to pip that have been fixed, and we _shouldn't_ need to import dask anymore.