### PR TITLE
Add VersionVigilante workflow

### DIFF
--- a/.github/workflows/VersionVigilante.yml
+++ b/.github/workflows/VersionVigilante.yml
@@ -1,0 +1,31 @@
+name: VersionVigilante
+
+on: pull_request
+
+jobs:
+  VersionVigilante:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+      - name: VersionVigilante.main
+        id: versionvigilante_main
+        run: |
+          julia -e 'using Pkg; Pkg.add("VersionVigilante")'
+          julia -e 'using VersionVigilante; VersionVigilante.main("https://github.com/${{ github.repository }}")'
+      - name: ✅ Un-Labeller (if success)
+        if: (steps.versionvigilante_main.outputs.compare_versions == 'success') && (success() || failure())
+        continue-on-error: true
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.removeLabel({...context.issue, name: 'needs version bump'})
+      - name: ❌ Labeller (if failure)
+        if: (steps.versionvigilante_main.outputs.compare_versions == 'failure') && (success() || failure())
+        continue-on-error: true
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({...context.issue, labels: ['needs version bump']})


### PR DESCRIPTION
This package employs a continuous delivery model, wherein every PR that touches code (and even in some cases touches documentation) requires a new release. VersionVigilante enforces a slightly stricter requirement than this: that every PR has a version bump. We can of course ignore it for PRs that don't touch code, but this will at least remind any contributors to check if they need a version bump.