### PR TITLE
Remove hpd, plot_hpd, and geweke

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.4.11"
+version = "0.5.0-DEV"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,12 +43,12 @@
 
 ## [Diagnostics](@id diagnostics-api)
 
-| Name             | Description                                                              |
-|:---------------- |:------------------------------------------------------------------------ |
-| [`bfmi`](@ref)   | Calculate the estimated Bayesian fraction of missing information (BFMI). |
-| [`ess`](@ref)    | Calculate estimate of the effective sample size (ESS).                   |
-| [`rhat`](@ref)   | Compute estimate of rank normalized split-$\hat{R}$ for a set of traces. |
-| [`mcse`](@ref)   | Calculate Markov Chain Standard Error statistic (MCSE).                  |
+| Name           | Description                                                              |
+|:-------------- |:------------------------------------------------------------------------ |
+| [`bfmi`](@ref) | Calculate the estimated Bayesian fraction of missing information (BFMI). |
+| [`ess`](@ref)  | Calculate estimate of the effective sample size (ESS).                   |
+| [`rhat`](@ref) | Compute estimate of rank normalized split-$\hat{R}$ for a set of traces. |
+| [`mcse`](@ref) | Calculate Markov Chain Standard Error statistic (MCSE).                  |
 
 ## [Stats utils](@id statsutils-api)
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,7 +46,6 @@
 | Name             | Description                                                              |
 |:---------------- |:------------------------------------------------------------------------ |
 | [`bfmi`](@ref)   | Calculate the estimated Bayesian fraction of missing information (BFMI). |
-| [`geweke`](@ref) | Compute $z$-scores for convergence diagnostics.                          |
 | [`ess`](@ref)    | Calculate estimate of the effective sample size (ESS).                   |
 | [`rhat`](@ref)   | Compute estimate of rank normalized split-$\hat{R}$ for a set of traces. |
 | [`mcse`](@ref)   | Calculate Markov Chain Standard Error statistic (MCSE).                  |

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -61,7 +61,7 @@ export plot_autocorr,
 export summarystats, compare, hdi, loo, loo_pit, psislw, r2_score, waic
 
 ## Diagnostics
-export bfmi, geweke, ess, rhat, mcse
+export bfmi, ess, rhat, mcse
 
 ## Stats utils
 export autocov, autocorr, make_ufunc, wrap_xarray_ufunc

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,6 +1,5 @@
 @forwardfun bfmi
 @forwardfun ess
-@forwardfun geweke
 @forwardfun mcse
 @forwardfun rhat
 

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -22,7 +22,6 @@
 @forwardplotfun plot_trace
 @forwardplotfun plot_violin
 
-@deprecate plot_hpd(args...; kwargs...) plot_hdi(args...; kwargs...)
 @deprecate plot_joint(args...; kwargs...) plot_pair(args...; kwargs...)
 
 function convert_arguments(::typeof(plot_compare), df, args...; kwargs...)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -19,8 +19,6 @@ const sample_stats_types = Dict(
 @forwardfun r2_score
 @forwardfun waic
 
-@deprecate hpd(args...; kwargs...) hdi(args...; kwargs...)
-
 for f in (:loo, :waic)
     @eval begin
         function convert_arguments(::typeof($(f)), data, args...; kwargs...)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -30,10 +30,4 @@
         @test rhat((x=arr,)) isa ArviZ.Dataset
         @test rhat((x=arr,)).x.values == ArviZ.arviz.rhat(Dict(:x => arr)).x.values
     end
-
-    @testset "geweke" begin
-        rng = Random.MersenneTwister(42)
-        arr = randn(rng, 1000)
-        @test geweke(arr, 0.1, 0.5, 10) == ArviZ.arviz.geweke(arr, 0.1, 0.5, 10)
-    end
 end

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -116,14 +116,14 @@ using PyCall, PyPlot
         end
     end
 
-    @testset "$f" for f in (plot_hpd, plot_hdi)
+    @testset "plot_hdi"
         x_data = randn(rng, 100)
         y_data = 2 .+ x_data .* 0.5
         y_data_rep = 0.5 .* randn(rng, 200, 100) .+ transpose(y_data)
-        f(x_data, y_data_rep)
+        plot_hdi(x_data, y_data_rep)
         close(gcf())
         ispynull(ArviZ.bokeh) || @testset "bokeh" begin
-            @test f(x_data, y_data_rep; backend=:bokeh) isa ArviZ.BokehPlot
+            @test plot_hdi(x_data, y_data_rep; backend=:bokeh) isa ArviZ.BokehPlot
         end
     end
 

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -116,7 +116,7 @@ using PyCall, PyPlot
         end
     end
 
-    @testset "plot_hdi"
+    @testset "plot_hdi" begin
         x_data = randn(rng, 100)
         y_data = 2 .+ x_data .* 0.5
         y_data_rep = 0.5 .* randn(rng, 200, 100) .+ transpose(y_data)

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -9,12 +9,6 @@ using DataFrames: DataFrames
         @test df isa DataFrames.DataFrame
     end
 
-    @testset "hpd" begin
-        rng = Random.MersenneTwister(42)
-        x = randn(rng, 100)
-        @test hpd(x) == ArviZ.arviz.hdi(x)
-    end
-
     @testset "hdi" begin
         rng = Random.MersenneTwister(42)
         x = randn(rng, 100)


### PR DESCRIPTION
`hpd` and `plot_hpd` were already deprecated both here and in arviz and were removed in arviz v0.11.2 (https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0112-2021-feb-21). `geweke` likewise was removed in the same release. This PR also removes them here.

Because these were API functions, this is a breaking change by semvar, and the minor version is updated accordingly. Because we will make a few other breaking changes before the next release, the version number has a `-DEV` designation.