### PR TITLE
Test both old and new variable name formats in summarystats

### DIFF
--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -63,9 +63,10 @@ using DataFrames: DataFrames
         @test :variable in propertynames(summarystats(idata; fmt="wide"))
         @test "a" ∈ s.variable
         @test "b" ∉ s.variable
-        @test "b[0,0]" ∉ s.variable
-        @test "b[1,1]" ∈ s.variable
-        @test "b[0,0]" ∈ summarystats(idata; index_origin=0).variable
+        @test "b[0,0]" ∉ s.variable && "b[0, 0]" ∉ s.variable
+        @test "b[1,1]" ∈ s.variable || "b[1, 1]" ∈ s.variable
+        var_summary = summarystats(idata; index_origin=0).variable
+        @test "b[0,0]" ∈ var_summary || "b[0, 0]" ∈ var_summary
 
         s2 = summarystats(idata; fmt="long")
         @test s2 isa DataFrames.DataFrame


### PR DESCRIPTION
A recent release of arviz changed the variable name formats for matrix and multi-dimensional variables in `arviz.summary` (our `summarystats`) to have a space after the comma. e.g. `"b[1,1]"` is now `"b[1, 1]"`. To be compatible with both old and new versions of arviz, this PR updates the test for variable names accordingly.