### PR TITLE
Update MCMCChains sample_stats names to match scheme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.0-DEV"
+version = "0.5.0"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -85,7 +85,7 @@ export with_interactive_backend
 ## rcParams
 export rcParams, with_rc_context
 
-const _min_arviz_version = v"0.10.0"
+const _min_arviz_version = v"0.11.0"
 const arviz = PyNULL()
 const xarray = PyNULL()
 const bokeh = PyNULL()

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -1,12 +1,9 @@
 const turing_key_map = Dict(
-    "acceptance_rate" => "mean_tree_accept",
     "hamiltonian_energy" => "energy",
     "hamiltonian_energy_error" => "energy_error",
     "is_adapt" => "tune",
     "max_hamiltonian_energy_error" => "max_energy_error",
-    "n_steps" => "tree_size",
     "numerical_error" => "diverging",
-    "tree_depth" => "depth",
 )
 const stan_key_map = Dict(
     "accept_stat__" => "acceptance_rate",

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -4,6 +4,7 @@ const turing_key_map = Dict(
     "is_adapt" => "tune",
     "max_hamiltonian_energy_error" => "max_energy_error",
     "numerical_error" => "diverging",
+    "nom_step_size" => "step_size_nom",
 )
 const stan_key_map = Dict(
     "accept_stat__" => "acceptance_rate",

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -3,8 +3,8 @@ const turing_key_map = Dict(
     "hamiltonian_energy_error" => "energy_error",
     "is_adapt" => "tune",
     "max_hamiltonian_energy_error" => "max_energy_error",
-    "numerical_error" => "diverging",
     "nom_step_size" => "step_size_nom",
+    "numerical_error" => "diverging",
 )
 const stan_key_map = Dict(
     "accept_stat__" => "acceptance_rate",

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -9,13 +9,13 @@ const turing_key_map = Dict(
     "tree_depth" => "depth",
 )
 const stan_key_map = Dict(
-    "accept_stat__" => "accept_stat",
+    "accept_stat__" => "acceptance_rate",
     "divergent__" => "diverging",
     "energy__" => "energy",
     "lp__" => "lp",
-    "n_leapfrog__" => "n_leapfrog",
-    "stepsize__" => "stepsize",
-    "treedepth__" => "treedepth",
+    "n_leapfrog__" => "n_steps",
+    "stepsize__" => "step_size",
+    "treedepth__" => "tree_depth",
 )
 const stats_key_map = merge(turing_key_map, stan_key_map)
 


### PR DESCRIPTION
arviz v0.11.0 updated the scheme for stat names in the `sample_stats` group (see https://github.com/arviz-devs/arviz/pull/1063). arviz v0.11.2 updated many converters to satisfy this schema (see https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#v0112-2021-feb-21). This PR updates the name mapping for `CmdStan.jl`/`Stan.jl` outputs stored in `MCMCChains.Chains` objects to be consistent with this scheme (fixes part of #31). It also fixes a few outdated name mappings for Turing's `Chains` outputs.