### PR TITLE
Add scheduled futures CI run to workflow

### DIFF
--- a/.github/workflows/futures.yml
+++ b/.github/workflows/futures.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
     tags: [v*]
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   PYTHON: "Conda" # use Julia's packaged Conda build for installing packages


### PR DESCRIPTION
This ensures that if we don't update for aa day or more, our futures CI still catches breaking changes in nightly Julia versions and the main branch of arviz.