### PR TITLE
Update the Turing example

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -13,4 +13,4 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 [compat]
 MCMCChains = "3.0, 4.0"
 Soss = "0.11, 0.12, 0.13, 0.14"
-Turing = "0.14.9"
+Turing = "0.15"

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -78,16 +78,12 @@ Now we write and run the model using Turing:
 ```@example quickstart
 using Turing
 
-Turing.@model function turing_model(J, y, σ, ::Type{TV}=Vector{Float64}) where {TV}
-    begin
-        μ ~ Normal(0, 5)
-        τ ~ truncated(Cauchy(0, 5), 0, Inf)
-        θ = TV(undef, J)
-        θ .~ Normal(μ, τ)
-        for i in eachindex(y)
-            y[i] ~ Normal(θ[i], σ[i])
-        end
-        return y
+Turing.@model function turing_model(J, y, σ)
+    μ ~ Normal(0, 5)
+    τ ~ truncated(Cauchy(0, 5), 0, Inf)
+    θ ~ filldist(Normal(μ, τ), J)
+    for i in eachindex(y)
+        y[i] ~ Normal(θ[i], σ[i])
     end
 end
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -78,7 +78,7 @@ Now we write and run the model using Turing:
 ```@example quickstart
 using Turing
 
-Turing.@model function turing_model(y, σ, J = length(y))
+Turing.@model function turing_model(y, σ, J=length(y))
     μ ~ Normal(0, 5)
     τ ~ truncated(Cauchy(0, 5), 0, Inf)
     θ ~ filldist(Normal(μ, τ), J)

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -92,7 +92,7 @@ sampler = NUTS(nwarmup, 0.8)
 
 rng = Random.MersenneTwister(16653)
 turing_chns = sample(
-    rng, param_mod, sampler, MCMCThreads(), nwarmup + nsamples, nchains; progress=false
+    rng, param_mod, sampler, MCMCThreads(), nsamples, nchains; progress=false
 );
 nothing # hide
 ```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -78,16 +78,16 @@ Now we write and run the model using Turing:
 ```@example quickstart
 using Turing
 
-Turing.@model function turing_model(J, y, σ)
+Turing.@model function turing_model(y, σ, J = length(y))
     μ ~ Normal(0, 5)
     τ ~ truncated(Cauchy(0, 5), 0, Inf)
     θ ~ filldist(Normal(μ, τ), J)
-    for i in eachindex(y)
+    for i in 1:J
         y[i] ~ Normal(θ[i], σ[i])
     end
 end
 
-param_mod = turing_model(J, y, σ)
+param_mod = turing_model(y, σ)
 sampler = NUTS(nwarmup, 0.8)
 
 rng = Random.MersenneTwister(16653)
@@ -161,7 +161,7 @@ To draw from the prior and posterior predictive distributions we can instantiate
 
 ```@example quickstart
 # Instantiate the predictive model
-param_mod_predict = turing_model(J, similar(y, Missing), σ)
+param_mod_predict = turing_model(similar(y, Missing), σ)
 # and then sample!
 prior_predictive = predict(param_mod_predict, prior)
 posterior_predictive = predict(param_mod_predict, turing_chns)


### PR DESCRIPTION
On recent versions of Turing, the example in the docs stopped working. This PR updates it to use some of Turing's modern syntax:
- Remove the optional type argument from the model
- Use `fill_dist` to declare iid random variables
- Now Turing takes number of draws to be returned as an argument, whereas before it took number of draws plus number of warmup steps.
- make length of `y` an optional argument