### PR TITLE
add analytics to docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ makedocs(;
         canonical="stable",
     ),
     linkcheck=true,
-    analytics = "G-W1G68W77YV",
+    analytics="G-W1G68W77YV",
 )
 
 deploydocs(; repo="github.com/arviz-devs/ArviZ.jl.git", push_preview=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
         canonical="stable",
     ),
     linkcheck=true,
+    analytics = "G-W1G68W77YV",
 )
 
 deploydocs(; repo="github.com/arviz-devs/ArviZ.jl.git", push_preview=true)


### PR DESCRIPTION
Adds google analytics to the documentation page. We'll then gather some data now and after season of
docs we'll be able to see if there is an increase in traffic and retention of visitors.
