### PR TITLE
Evaluate quickstart sections in different modules

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -34,10 +34,10 @@ using Distributions
 s = (10, 50)
 plot_forest(
     Dict(
-        "normal" => randn(s),
-        "gumbel" => rand(Gumbel(), s),
-        "student t" => rand(TDist(6), s),
-        "exponential" => rand(Exponential(), s),
+        "normal" => randn(rng, s),
+        "gumbel" => rand(rng, Gumbel(), s),
+        "student t" => rand(rng, TDist(6), s),
+        "exponential" => rand(rng, Exponential(), s),
     ),
 );
 gcf()


### PR DESCRIPTION
According to [the Documenter docs](https://juliadocs.github.io/Documenter.jl/stable/man/syntax/#@example-block), by default `@example` blocks with different names or no names are evaluated in different modules to prevent bad side-effects between blocks. It is possible such a bad interaction is currently causing the docs build to hang while building the Quickstart page. This PR gives each section of the quickstart a different name for the `@example` blocks to try to avoid these interactions in the future.