### PR TITLE
Sort variable indices from MCMCChains ourselves

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,4 +16,4 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 [compat]
 MCMCChains = "3.0, 4.0"
 Soss = "0.20"
-Turing = "0.15"
+Turing = "0.15, 0.16"

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -20,10 +20,10 @@ const stats_key_map = merge(turing_key_map, stan_key_map)
 """
     reshape_values(x::AbstractArray) -> AbstractArray
 
-Convert from `MCMCChains` variable values with dimensions `(ndraw, size..., nchain)` to
+Convert from `MCMCChains` variable values with dimensions `(ndraw, nchain, size...)` to
 ArviZ's expected `(nchain, ndraw, size...)`.
 """
-reshape_values(x::AbstractArray{T,N}) where {T,N} = permutedims(x, (N, 1, 2:(N - 1)...))
+reshape_values(x::AbstractArray{T,N}) where {T,N} = permutedims(x, (2, 1, (3:N)...))
 
 headtail(x) = x[1], x[2:end]
 
@@ -75,8 +75,8 @@ function section_dict(chns::Chains, section)
         loc_names, locs = names_locs
         sizes = reduce((a, b) -> max.(a, b), locs)
         ndim = length(sizes)
-
-        oldarr = reshape_values(replacemissing(convert(Array, chns.value[:, loc_names, :])))
+        var_views = (@view(chns.value[:, n, :]) for n in loc_names)
+        oldarr = reshape_values(replacemissing(convert(Array, cat(var_views...; dims=3))))
         if iszero(ndim)
             arr = dropdims(oldarr; dims=3)
         else

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -67,9 +67,8 @@ function section_dict(chns::Chains, section)
     vars_to_arrays = Dict{String,Array}()
     for (var_name, names_locs) in vars_to_locs
         loc_names, locs = names_locs
-        max_loc = maximum(reduce(hcat, [loc...] for loc in locs); dims=2)
-        ndim = length(max_loc)
-        sizes = tuple(max_loc...)
+        sizes = reduce((a, b) -> max.(a, b), locs)
+        ndim = length(sizes)
 
         oldarr = reshape_values(replacemissing(convert(Array, chns.value[:, loc_names, :])))
         if iszero(ndim)

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -48,6 +48,12 @@ function varnames_locs_dict(loc_names, loc_str_to_old)
             push!(vars_to_locs[var_name][2], loc)
         end
     end
+    # ensure that elements are ordered in the same order as they would be iterated
+    for loc_name_locs in values(vars_to_locs)
+        perm = sortperm(loc_name_locs[2]; by=CartesianIndex)
+        permute!(loc_name_locs[1], perm)
+        permute!(loc_name_locs[2], perm)
+    end
     return vars_to_locs
 end
 

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -1,6 +1,5 @@
 using MCMCChains: MCMCChains
 using CmdStan
-using StatsBase: mean
 
 const noncentered_schools_stan_model = """
     data {
@@ -311,23 +310,6 @@ end
     chn = MCMCChains.Chains(val)  # According to version, this may introduce String or Symbol name
 
     @test ArviZ.summary(chn) !== nothing
-end
-
-# https://github.com/arviz-devs/ArviZ.jl/issues/138
-@testset "Chains with unordered variables" begin
-    n_iter = 500
-    n_name = 4
-    n_chain = 2
-
-    vals = randn(n_iter, n_name, n_chain)
-    names = Symbol.(["x[2,2]", "x[2,1]", "x[1,1]", "x[1,2]"])
-    ordered_names = Symbol.(["x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]"])
-    chn = MCMCChains.Chains(vals, names)
-    idata = from_mcmcchains(chn)
-
-    means = dropdims(mean(idata.posterior.x.values; dims=(1, 2)); dims=(1, 2))
-    means_exp = reshape(map(name -> mean(chn[name]), ordered_names), 2, 2)
-    @test means ≈ means_exp
 end
 
 VERSION > v"1.0" && @testset "from_cmdstan" begin


### PR DESCRIPTION
Resolves issue where depending on how an `MCMCChains.Chains` was created, slicing variables from the underlying `AxisArray` may or may not return the subarray with the variables in the same order we requested. To avoid the issue, now we don't slice at all. Fixes #138.