### PR TITLE
Add compatibility with arviz v0.11.3 and up

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://arviz-devs.github.io/ArviZ.jl/dev/assets/logo.png" height=100></img>
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-![CI](https://github.com/arviz-devs/ArviZ.jl/workflows/CI/badge.svg)
+[![CI](https://github.com/arviz-devs/ArviZ.jl/workflows/CI/badge.svg)](https://github.com/arviz-devs/ArviZ.jl/actions/workflows/ci.yml?query=branch%3Amain)
 [![codecov.io](https://codecov.io/github/arviz-devs/ArviZ.jl/coverage.svg?branch=main)](https://codecov.io/github/arviz-devs/ArviZ.jl?branch=main)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://arviz-devs.github.io/ArviZ.jl/stable)

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -86,7 +86,7 @@ export with_interactive_backend
 ## rcParams
 export rcParams, with_rc_context
 
-const _min_arviz_version = v"0.11.0"
+const _min_arviz_version = v"0.11.3"
 const arviz = PyNULL()
 const xarray = PyNULL()
 const bokeh = PyNULL()

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -114,7 +114,7 @@ function StatsBase.summarystats(data::InferenceData; group=:posterior, kwargs...
     return summarystats(dataset; kwargs...)
 end
 function StatsBase.summarystats(data::Dataset; fmt=:wide, kwargs...)
-    s = arviz.summary(data; fmt=fmt, index_origin=index_origin,kwargs...)
+    s = arviz.summary(data; fmt=fmt, kwargs...)
     s isa Dataset && return s
     index_name = Symbol(fmt) == :long ? :statistic : :variable
     return todataframes(s; index_name=index_name)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -58,8 +58,6 @@ Compute summary statistics on `data`.
 - `hdi_prob::Real=0.94`: HDI interval to compute. This is only meaningful when `stat_funcs`
     is `nothing`.
 - `order::String="C"`: If `fmt` is "wide", use either "C" or "F" unpacking order.
-- `index_origin::Int=1`: If `fmt` is "wide", select 𝑛-based indexing for multivariate
-    parameters.
 - `skipna::Bool=false`: If `true`, ignores `NaN` values when computing the summary
     statistics. It does not affect the behaviour of the functions passed to `stat_funcs`.
 - `coords::Dict{String,Vector}=Dict()`: Coordinates specification to be used if the `fmt`
@@ -115,8 +113,8 @@ function StatsBase.summarystats(data::InferenceData; group=:posterior, kwargs...
     dataset = getproperty(data, Symbol(group))
     return summarystats(dataset; kwargs...)
 end
-function StatsBase.summarystats(data::Dataset; index_origin=1, fmt=:wide, kwargs...)
-    s = arviz.summary(data; index_origin=index_origin, fmt=fmt, kwargs...)
+function StatsBase.summarystats(data::Dataset; fmt=:wide, kwargs...)
+    s = arviz.summary(data; fmt=fmt, index_origin=index_origin,kwargs...)
     s isa Dataset && return s
     index_name = Symbol(fmt) == :long ? :statistic : :variable
     return todataframes(s; index_name=index_name)

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -57,10 +57,8 @@ using DataFrames: DataFrames
         @test :variable in propertynames(summarystats(idata; fmt="wide"))
         @test "a" ∈ s.variable
         @test "b" ∉ s.variable
-        @test "b[0,0]" ∉ s.variable && "b[0, 0]" ∉ s.variable
-        @test "b[1,1]" ∈ s.variable || "b[1, 1]" ∈ s.variable
-        var_summary = summarystats(idata; index_origin=0).variable
-        @test "b[0,0]" ∈ var_summary || "b[0, 0]" ∈ var_summary
+        @test "b[0, 0]" ∉ s.variable
+        @test "b[1, 1]" ∈ s.variable
 
         s2 = summarystats(idata; fmt="long")
         @test s2 isa DataFrames.DataFrame


### PR DESCRIPTION
Bumps minimum required version of arviz to v0.11.3 and removes explicit resetting of `index_origin` by `summarystats`.