### PR TITLE
Fix psis test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -41,11 +41,15 @@ using DataFrames: DataFrames
             @test k ≈ result.pareto_shape
 
             # check against Python ArviZ
-            # NOTE: currently these implementations disagree
-            # see https://github.com/arviz-devs/arviz/issues/1941
             logw_smoothed2, k2 = ArviZ.arviz.psislw(copy(logw), 0.9)
+            # NOTE: currently the smoothed weights disagree, while the shapes agree
+            # see https://github.com/arviz-devs/arviz/issues/1941
             @test_broken logw_smoothed ≈ logw_smoothed2
-            @test_broken k ≈ k2
+            if length(sz) == 1
+                @test k ≈ k2[] # k2 is a 0-dimensional array
+            else
+                @test k ≈ k2
+            end
         end
     end
 


### PR DESCRIPTION
The test incorrectly assumed the shapes computed with PSIS.jl vs `arviz.psis` should disagree, when in fact they should agree. The test problem was obscured by `psis` returning a 0-dimensional array with a single entry, which fails the approximate equality check with the scalar returned by `PSIS.psis` based purely on types. This PR fixes the test.