### PR TITLE
Use test-specific Project.toml and clean up workflows

### DIFF
--- a/.github/workflows/VersionVigilante.yml
+++ b/.github/workflows/VersionVigilante.yml
@@ -26,7 +26,12 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.rest.issues.removeLabel({...context.issue, name: 'needs version bump'})
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'needs version bump'
+            })
       - name: ❌ Labeller (if failure)
         if: (steps.versionvigilante_main.outputs.compare_versions == 'failure') && (success() || failure())
         continue-on-error: true
@@ -34,4 +39,9 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.rest.issues.addLabels({...context.issue, labels: ['needs version bump']})
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['needs version bump']
+            })

--- a/.github/workflows/VersionVigilante.yml
+++ b/.github/workflows/VersionVigilante.yml
@@ -22,16 +22,16 @@ jobs:
       - name: ✅ Un-Labeller (if success)
         if: (steps.versionvigilante_main.outputs.compare_versions == 'success') && (success() || failure())
         continue-on-error: true
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.removeLabel({...context.issue, name: 'needs version bump'})
+            github.rest.issues.removeLabel({...context.issue, name: 'needs version bump'})
       - name: ❌ Labeller (if failure)
         if: (steps.versionvigilante_main.outputs.compare_versions == 'failure') && (success() || failure())
         continue-on-error: true
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.addLabels({...context.issue, labels: ['needs version bump']})
+            github.rest.issues.addLabels({...context.issue, labels: ['needs version bump']})

--- a/.github/workflows/VersionVigilante.yml
+++ b/.github/workflows/VersionVigilante.yml
@@ -22,7 +22,7 @@ jobs:
       - name: ✅ Un-Labeller (if success)
         if: (steps.versionvigilante_main.outputs.compare_versions == 'success') && (success() || failure())
         continue-on-error: true
-        uses: actions/github-script@5
+        uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -30,7 +30,7 @@ jobs:
       - name: ❌ Labeller (if failure)
         if: (steps.versionvigilante_main.outputs.compare_versions == 'failure') && (success() || failure())
         continue-on-error: true
-        uses: actions/github-script@5
+        uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1.0, 1]
+        julia-version: ["1.2", "1.6", "1"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1.2", "1.6", "1"]
+        julia-version: ["1.6", "1"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install JuliaFormatter
         run: |
           using Pkg

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.9"
+version = "0.5.10"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/Project.toml
+++ b/Project.toml
@@ -17,30 +17,13 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-CmdStan = "5.2.3, 6.0"
 Conda = "1.0"
 DataFrames = "0.20, 0.21, 0.22, 1.0"
 LogExpFunctions = "0.2.0, 0.3"
-MCMCChains = "0.3.15, 0.4, 1.0, 2.0, 3.0, 4.0, 5.0"
-MonteCarloMeasurements = "0.6.4, 0.7, 0.8, 1"
 NamedTupleTools = "0.11.0, 0.12, 0.13"
 PSIS = "0.2"
 PyCall = "1.91.2"
 PyPlot = "2.8.2"
 Requires = "0.5.2, 1.0"
-SampleChains = "0.5"
-SampleChainsDynamicHMC = "0.3"
 StatsBase = "0.32, 0.33"
 julia = "^1"
-
-[extras]
-CmdStan = "593b3428-ca2f-500c-ae53-031589ec8ddd"
-MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
-MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SampleChains = "754583d1-7fc4-4dab-93b5-5eaca5c9622e"
-SampleChainsDynamicHMC = "6d9fd711-e8b2-4778-9c70-c1dfb499d4c4"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["CmdStan", "MCMCChains", "MonteCarloMeasurements", "Random", "SampleChains", "SampleChainsDynamicHMC", "Test"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,21 @@
+[deps]
+CmdStan = "5.2.3, 6.0"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+MCMCChains = "0.3.15, 0.4, 1.0, 2.0, 3.0, 4.0, 5.0"
+MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SampleChains = "754583d1-7fc4-4dab-93b5-5eaca5c9622e"
+SampleChainsDynamicHMC = "6d9fd711-e8b2-4778-9c70-c1dfb499d4c4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+CmdStan = "5.2.3, 6.0"
+DataFrames = "0.20, 0.21, 0.22, 1.0"
+MCMCChains = "0.3.15, 0.4, 1.0, 2.0, 3.0, 4.0, 5.0"
+MonteCarloMeasurements = "0.6.4, 0.7, 0.8, 1"
+PyCall = "1.91.2"
+PyPlot = "2.8.2"
+SampleChains = "0.5"
+SampleChainsDynamicHMC = "0.3"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,7 @@
 [deps]
-CmdStan = "5.2.3, 6.0"
+CmdStan = "593b3428-ca2f-500c-ae53-031589ec8ddd"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-MCMCChains = "0.3.15, 0.4, 1.0, 2.0, 3.0, 4.0, 5.0"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"


### PR DESCRIPTION
This PR does a few things related to the CI:
- move dependencies only for tests to `test/Project.toml`. Because this is only supported by v1.2 and later, we also update the CI to run on v1.2, v1.6 (latest LTS), and v1 (latest version).
- remove compat entries optional dependencies. These are ignored by Pkg.jl anyways (see https://github.com/JuliaLang/Pkg.jl/issues/1285)
- Fix #145
- Update the VersionVigilante workflow to use `github-script@v5` instead of the recommended `github-script@v0.3.0`