### PR TITLE
Fix `StackOverflowError` of `from_mcmcchains` for large number of variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.12"
+version = "0.5.13"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -17,14 +17,6 @@ const stan_key_map = Dict(
 )
 const stats_key_map = merge(turing_key_map, stan_key_map)
 
-"""
-    reshape_values(x::AbstractArray) -> AbstractArray
-
-Convert from `MCMCChains` variable values with dimensions `(ndraw, nchain, size...)` to
-ArviZ's expected `(nchain, ndraw, size...)`.
-"""
-reshape_values(x::AbstractArray{T,N}) where {T,N} = permutedims(x, (2, 1, (3:N)...))
-
 headtail(x) = x[1], x[2:end]
 
 function split_locname(name)
@@ -75,24 +67,16 @@ function section_dict(chns::Chains, section)
         loc_names, locs = names_locs
         sizes = reduce((a, b) -> max.(a, b), locs)
         ndim = length(sizes)
-        var_views = (@view(chns.value[:, n, :]) for n in loc_names)
-        oldarr = let init = first(var_views)
-            # Splatting can be _very_ slow when `length(var_views)` is high,
-            # sometimes even resulting in `StackOverflowError`. Hence we use `reduce` with `cat` instead.
-            arr = reduce(
-                (x, y) -> cat(x, y; dims=3),
-                Iterators.drop(var_views, 1);
-                init=reshape(init, size(init)..., 1),
-            )
-            reshape_values(replacemissing(convert(Array, arr)))
-        end
+        # NOTE: slicing specific entries from AxisArrays does not preserve order
+        # https://github.com/JuliaArrays/AxisArrays.jl/issues/182
+        oldarr = replacemissing(permutedims(chns.value[:, loc_names, :], (3, 1, 2)))
         if iszero(ndim)
             arr = dropdims(oldarr; dims=3)
         else
             arr = Array{Union{typeof(NaN),eltype(oldarr)}}(undef, nchains, ndraws, sizes...)
             fill!(arr, NaN)
-            for i in eachindex(locs)
-                arr[:, :, locs[i]...] = oldarr[:, :, i]
+            for i in eachindex(locs, loc_names)
+                arr[:, :, locs[i]...] = oldarr[:, :, loc_names[i]]
             end
         end
         vars_to_arrays[var_name] = arr

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -77,7 +77,8 @@ function section_dict(chns::Chains, section)
         ndim = length(sizes)
         var_views = (@view(chns.value[:, n, :]) for n in loc_names)
         oldarr = let init = first(var_views)
-            # Splatting can result in `StackOverflowError`, so we use `reduce` with `cat` instead.
+            # Splatting can be _very_ slow when `length(var_views)` is high,
+            # sometimes even resulting in `StackOverflowError`. Hence we use `reduce` with `cat` instead.
             arr = reduce((x, y) -> cat(x, y; dims=3), Iterators.drop(var_views, 1); init=reshape(init, size(init)..., 1))
             reshape_values(replacemissing(convert(Array, arr)))
         end

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -76,7 +76,7 @@ function section_dict(chns::Chains, section)
             arr = Array{Union{typeof(NaN),eltype(oldarr)}}(undef, nchains, ndraws, sizes...)
             fill!(arr, NaN)
             for i in eachindex(locs, loc_names)
-                arr[:, :, locs[i]...] = oldarr[:, :, loc_names[i]]
+                @views arr[:, :, locs[i]...] = oldarr[:, :, loc_names[i]]
             end
         end
         vars_to_arrays[var_name] = arr

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -79,7 +79,11 @@ function section_dict(chns::Chains, section)
         oldarr = let init = first(var_views)
             # Splatting can be _very_ slow when `length(var_views)` is high,
             # sometimes even resulting in `StackOverflowError`. Hence we use `reduce` with `cat` instead.
-            arr = reduce((x, y) -> cat(x, y; dims=3), Iterators.drop(var_views, 1); init=reshape(init, size(init)..., 1))
+            arr = reduce(
+                (x, y) -> cat(x, y; dims=3),
+                Iterators.drop(var_views, 1);
+                init=reshape(init, size(init)..., 1),
+            )
             reshape_values(replacemissing(convert(Array, arr)))
         end
         if iszero(ndim)

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -76,9 +76,16 @@ function section_dict(chns::Chains, section)
         sizes = reduce((a, b) -> max.(a, b), locs)
         ndim = length(sizes)
         var_views = (@view(chns.value[:, n, :]) for n in loc_names)
-        # NOTE: slicing specific entries from AxisArrays does not preserve order
-        # https://github.com/JuliaArrays/AxisArrays.jl/issues/182
-        oldarr = permutedims(reshape_values(chns.value[:, loc_names, :]))
+        oldarr = let init = first(var_views)
+            # Splatting can be _very_ slow when `length(var_views)` is high,
+            # sometimes even resulting in `StackOverflowError`. Hence we use `reduce` with `cat` instead.
+            arr = reduce(
+                (x, y) -> cat(x, y; dims=3),
+                Iterators.drop(var_views, 1);
+                init=reshape(init, size(init)..., 1),
+            )
+            reshape_values(replacemissing(convert(Array, arr)))
+        end
         if iszero(ndim)
             arr = dropdims(oldarr; dims=3)
         else

--- a/src/mcmcchains.jl
+++ b/src/mcmcchains.jl
@@ -76,16 +76,9 @@ function section_dict(chns::Chains, section)
         sizes = reduce((a, b) -> max.(a, b), locs)
         ndim = length(sizes)
         var_views = (@view(chns.value[:, n, :]) for n in loc_names)
-        oldarr = let init = first(var_views)
-            # Splatting can be _very_ slow when `length(var_views)` is high,
-            # sometimes even resulting in `StackOverflowError`. Hence we use `reduce` with `cat` instead.
-            arr = reduce(
-                (x, y) -> cat(x, y; dims=3),
-                Iterators.drop(var_views, 1);
-                init=reshape(init, size(init)..., 1),
-            )
-            reshape_values(replacemissing(convert(Array, arr)))
-        end
+        # NOTE: slicing specific entries from AxisArrays does not preserve order
+        # https://github.com/JuliaArrays/AxisArrays.jl/issues/182
+        oldarr = permutedims(reshape_values(chns.value[:, loc_names, :]))
         if iszero(ndim)
             arr = dropdims(oldarr; dims=3)
         else

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -291,6 +291,12 @@ end
             randn(100, num_vars, 1), [Symbol("x[$i]") for i in 1:num_vars]
         )
         @test hasproperty(from_mcmcchains(chn).posterior, :x)
+
+        num_vars = 100
+        chn = MCMCChains.Chains(
+            randn(100, num_vars^2, 1), [Symbol("x[$i, $j]") for i = 1:num_vars, j = 1:num_vars]
+        )
+        @test hasproperty(from_mcmcchains(chn).posterior, :x)
     end
 end
 

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -286,8 +286,10 @@ end
     end
 
     @testset "large number of variables" begin
-        num_vars = 1_000;
-        chn = MCMCChains.Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars])
+        num_vars = 1_000
+        chn = MCMCChains.Chains(
+            randn(100, num_vars, 1), [Symbol("x[$i]") for i in 1:num_vars]
+        )
         @test hasproperty(from_mcmcchains(chn).posterior, :x)
     end
 end

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -295,7 +295,8 @@ end
 
         num_vars = 100
         chn = MCMCChains.Chains(
-            randn(100, num_vars^2, 1), [Symbol("x[$i,$j]") for i = 1:num_vars for j = 1:num_vars]
+            randn(100, num_vars^2, 1),
+            [Symbol("x[$i,$j]") for i in 1:num_vars for j in 1:num_vars],
         )
         @test hasproperty(from_mcmcchains(chn).posterior, :x)
     end

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -285,6 +285,7 @@ end
         @test attrs["inference_library"] == "MyLib"
     end
 
+    # https://github.com/arviz-devs/ArviZ.jl/issues/140
     @testset "large number of variables" begin
         num_vars = 1_000
         chn = MCMCChains.Chains(

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -284,6 +284,12 @@ end
         @test attrs isa Dict
         @test attrs["inference_library"] == "MyLib"
     end
+
+    @testset "large number of variables" begin
+        num_vars = 1_000;
+        chn = Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars])
+        @test haskey(from_mcmcchains(chn).posterior, :x)
+    end
 end
 
 @testset "convert_to_dataset(::MCMCChains.Chains)" begin

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -295,7 +295,7 @@ end
 
         num_vars = 100
         chn = MCMCChains.Chains(
-            randn(100, num_vars^2, 1), [Symbol("x[$i,$j]") for i = 1:num_vars, j = 1:num_vars]
+            randn(100, num_vars^2, 1), [Symbol("x[$i,$j]") for i = 1:num_vars for j = 1:num_vars]
         )
         @test hasproperty(from_mcmcchains(chn).posterior, :x)
     end

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -288,7 +288,7 @@ end
     @testset "large number of variables" begin
         num_vars = 1_000;
         chn = MCMCChains.Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars])
-        @test haskey(from_mcmcchains(chn).posterior, :x)
+        @test hasproperty(from_mcmcchains(chn).posterior, :x)
     end
 end
 

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -294,7 +294,7 @@ end
 
         num_vars = 100
         chn = MCMCChains.Chains(
-            randn(100, num_vars^2, 1), [Symbol("x[$i, $j]") for i = 1:num_vars, j = 1:num_vars]
+            randn(100, num_vars^2, 1), [Symbol("x[$i,$j]") for i = 1:num_vars, j = 1:num_vars]
         )
         @test hasproperty(from_mcmcchains(chn).posterior, :x)
     end

--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -287,7 +287,7 @@ end
 
     @testset "large number of variables" begin
         num_vars = 1_000;
-        chn = Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars])
+        chn = MCMCChains.Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars])
         @test haskey(from_mcmcchains(chn).posterior, :x)
     end
 end


### PR DESCRIPTION
On `#master`:

``` julia
julia> using MCMCChains, ArviZ

julia> num_vars = 1_000;

julia> chn = Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars]);

julia> @time from_mcmcchains(chn) # (×) `StackOverflowError` after quite a while...
```

(I couldn't actually reproduce the error; it just froze for ages :sweat_smile:)

In this PR:

``` julia
julia> using MCMCChains, ArviZ

julia> num_vars = 1_000;

julia> chn = Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars]);

julia> @time from_mcmcchains(chn) # (✓) Works!
  9.739639 seconds (22.51 M allocations: 1.699 GiB, 4.52% gc time)
InferenceData with groups:
        > posterior
```

``` julia
julia> versioninfo()
Julia Version 1.6.5
Commit 9058264a69 (2021-12-19 12:30 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)
```