### PR TITLE
Stop testing psis against Python arviz

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.19"
+version = "0.5.20"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -39,17 +39,6 @@ using DataFrames: DataFrames
             result = psis(copy(logw), 0.9)
             @test exp.(logw_smoothed) ≈ result.weights
             @test k ≈ result.pareto_shape
-
-            # check against Python ArviZ
-            logw_smoothed2, k2 = ArviZ.arviz.psislw(copy(logw), 0.9)
-            # NOTE: currently the smoothed weights disagree, while the shapes agree
-            # see https://github.com/arviz-devs/arviz/issues/1941
-            @test_broken logw_smoothed ≈ logw_smoothed2
-            if length(sz) == 1
-                @test k ≈ k2[] # k2 is a 0-dimensional array
-            else
-                @test k ≈ k2
-            end
         end
     end
 

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -42,9 +42,8 @@ using DataFrames: DataFrames
 
             # check against Python ArviZ
             logw_smoothed2, k2 = ArviZ.arviz.psislw(copy(logw), 0.9)
-            # NOTE: currently the smoothed weights disagree, while the shapes agree
-            # see https://github.com/arviz-devs/arviz/issues/1941
-            @test_broken logw_smoothed ≈ logw_smoothed2
+            # NOTE: sometimes the smoothed weights disagree, while the shapes agree
+            @test_skip logw_smoothed ≈ logw_smoothed2
             if length(sz) == 1
                 @test k ≈ k2[] # k2 is a 0-dimensional array
             else

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -39,6 +39,17 @@ using DataFrames: DataFrames
             result = psis(copy(logw), 0.9)
             @test exp.(logw_smoothed) ≈ result.weights
             @test k ≈ result.pareto_shape
+
+            # check against Python ArviZ
+            logw_smoothed2, k2 = ArviZ.arviz.psislw(copy(logw), 0.9)
+            # NOTE: currently the smoothed weights disagree, while the shapes agree
+            # see https://github.com/arviz-devs/arviz/issues/1941
+            @test_broken logw_smoothed ≈ logw_smoothed2
+            if length(sz) == 1
+                @test k ≈ k2[] # k2 is a 0-dimensional array
+            else
+                @test k ≈ k2
+            end
         end
     end
 


### PR DESCRIPTION
Testing `psis` (implemented in PSIS.jl) against Python arviz is somewhat brittle. For some seeds, they completely agree (for arviz v0.12.0 and higher). For others they slightly disagree. When they disagree, PSIS.jl's implementation, still agrees with loo's PSIS implementation.

Here's an example:
```julia
using ArviZ, RCall, Random, LogExpFunctions

rng = MersenneTwister(42)
log_ratios = randn(rng, 1_000)

# ArviZ.jl's psislw, wraps PSIS.psis
logw, k = psislw(copy(log_ratios))

# Python ArviZ's implementation
logw2, (k2,) = ArviZ.arviz.psislw(copy(log_ratios))

# LOO's implementation
R"""
require("loo")
res <- loo::psis($(copy(log_ratios)))
logw3 <- res$log_weights
k3 <- res$diagnostics$pareto_k
"""
@rget logw3
@rget k3
logw3 .-= logsumexp(logw3)

# compare
k ≈ k2  # true
k ≈ k3  # true
logw ≈ logw2 # false
logw ≈ logw3 # true
```

This PR removes the check against Python ArviZ's `psislw` implementation.