### PR TITLE
Update links to point to new domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ This is particularly the case for simple fixes, such as typos or tweaks to docum
 of time and attention.
 
 Contributors are also encouraged to contribute new code to enhance ArviZ.jl's functionality, also via pull requests.
-Please consult the [ArviZ.jl documentation](https://arviz-devs.github.io/ArviZ.jl/) to ensure that any new contribution does not strongly overlap with existing functionality.
+Please consult the [ArviZ.jl documentation](https://julia.arviz.org/) to ensure that any new contribution does not strongly overlap with existing functionality.
 
-In general, new analysis tools such as plots, statistics, and diagnostics should be contributed directly to [ArviZ](https://arviz-devs.github.io/arviz/).
+In general, new analysis tools such as plots, statistics, and diagnostics should be contributed directly to [ArviZ](https://python.arviz.org/).
 Julia-specific tools such as improvements to the API, documentation, custom types, conversion functions, and interfaces with other Julia packages should be added to ArviZ.jl.
 
 The preferred workflow for contributing to ArviZ.jl is to fork

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![CI](https://github.com/arviz-devs/ArviZ.jl/workflows/CI/badge.svg)](https://github.com/arviz-devs/ArviZ.jl/actions/workflows/ci.yml?query=branch%3Amain)
 [![codecov.io](https://codecov.io/github/arviz-devs/ArviZ.jl/coverage.svg?branch=main)](https://codecov.io/github/arviz-devs/ArviZ.jl?branch=main)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
-[![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://arviz-devs.github.io/ArviZ.jl/stable)
-[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://arviz-devs.github.io/ArviZ.jl/dev)
+[![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://julia.arviz.org/stable)
+[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://julia.arviz.org/dev)
 
-ArviZ.jl is a Julia interface to the [ArviZ](https://arviz-devs.github.io/arviz/) (pronounced "AR-_vees_") package for exploratory analysis of Bayesian models.
+ArviZ.jl is a Julia interface to the [ArviZ](https://python.arviz.org/) (pronounced "AR-_vees_") package for exploratory analysis of Bayesian models.
 It includes functions for posterior analysis, model checking, comparison and diagnostics.
 
-See the [documentation](https://arviz-devs.github.io/ArviZ.jl/stable) for details.
+See the [documentation](https://julia.arviz.org/stable) for details.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<img src="https://raw.githubusercontent.com/arviz-devs/arviz_governance/main/arviz_logos/ArviZ.png#gh-light-mode-only" width=200></img>
-<img src="https://raw.githubusercontent.com/arviz-devs/arviz_governance/main/arviz_logos/ArviZ_white.png#gh-dark-mode-only" width=200></img>
+<img src="https://raw.githubusercontent.com/arviz-devs/arviz-project/main/arviz_logos/ArviZ.png#gh-light-mode-only" width=200></img>
+<img src="https://raw.githubusercontent.com/arviz-devs/arviz-project/main/arviz_logos/ArviZ_white.png#gh-dark-mode-only" width=200></img>
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![CI](https://github.com/arviz-devs/ArviZ.jl/workflows/CI/badge.svg)](https://github.com/arviz-devs/ArviZ.jl/actions/workflows/ci.yml?query=branch%3Amain)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,7 @@ build_opts = PlutoStaticHTML.BuildOptions(
 PlutoStaticHTML.build_notebooks(build_opts)
 
 const ASSETS_DIR = joinpath(@__DIR__, "src", "assets")
-const ARVIZ_ASSETS_URL = "https://raw.githubusercontent.com/arviz-devs/arviz_governance/main/arviz_logos"
+const ARVIZ_ASSETS_URL = "https://raw.githubusercontent.com/arviz-devs/arviz-project/main/arviz_logos"
 
 function download_asset(remote_fn, fn=remote_fn)
     mkpath(ASSETS_DIR)

--- a/docs/src/bokeh_examples.md
+++ b/docs/src/bokeh_examples.md
@@ -2,4 +2,4 @@
 
 !!! note
     
-    See [ArviZ's bokeh gallery](https://arviz-devs.github.io/arviz/examples/index.html#bokeh) for examples.
+    See [ArviZ's bokeh gallery](https://python.arviz.org/en/latest/examples/index.html#bokeh) for examples.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,7 +18,7 @@ It also allows smoother usage with [PyPlot.jl](https://github.com/JuliaPy/PyPlot
 
 ## [Installation](@id installation)
 
-To use with the default Python environment, first [install ArviZ](https://github.com/arviz-devs/arviz#installation).
+To use with the default Python environment, first [install ArviZ](https://python.arviz.org/en/latest/getting_started/Installation.html).
 From the Julia REPL, type `]` to enter the Pkg REPL mode and run
 
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,16 +4,16 @@
 [![codecov.io](https://codecov.io/github/arviz-devs/ArviZ.jl/coverage.svg?branch=main)](https://codecov.io/github/arviz-devs/ArviZ.jl?branch=main)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
-ArviZ.jl is a Julia interface to the [ArviZ](https://arviz-devs.github.io/arviz/) package for exploratory analysis of Bayesian models.
+ArviZ.jl is a Julia interface to the [ArviZ](https://python.arviz.org/) package for exploratory analysis of Bayesian models.
 
-Please see [ArviZ's documentation](https://arviz-devs.github.io/arviz/) for detailed descriptions of features and usage.
-See for example the [gallery](https://arviz-devs.github.io/arviz/examples/index.html) for a sample of the plots and backends ArviZ supports.
+Please see [ArviZ's documentation](https://python.arviz.org/) for detailed descriptions of features and usage.
+See for example the [gallery](https://python.arviz.org/en/latest/examples/index.html) for a sample of the plots and backends ArviZ supports.
 
 This documentation will focus on differences between ArviZ.jl and ArviZ, applications using Julia's probabilistic programming languages (PPLs), and examples in Julia.
 
 ## [Purpose](@id purpose)
 
-Besides removing the need to explicitly import ArviZ with [PyCall.jl](https://github.com/JuliaPy/PyCall.jl), ArviZ.jl extends ArviZ with functionality for converting Julia types into ArviZ's [`InferenceData`](https://arviz-devs.github.io/arviz/getting_started/XarrayforArviZ.html) format.
+Besides removing the need to explicitly import ArviZ with [PyCall.jl](https://github.com/JuliaPy/PyCall.jl), ArviZ.jl extends ArviZ with functionality for converting Julia types into ArviZ's [`InferenceData`](https://python.arviz.org/en/latest/getting_started/XarrayforArviZ.html) format.
 It also allows smoother usage with [PyPlot.jl](https://github.com/JuliaPy/PyPlot.jl) and provides functions that can be overloaded by other packages to enable their types to be used with ArviZ.
 
 ## [Installation](@id installation)
@@ -35,7 +35,7 @@ For specifying other Python versions, see the [PyCall documentation](https://git
 
 ## [Design](@id design)
 
-ArviZ.jl supports all of ArviZ's [API](https://arviz-devs.github.io/arviz/api/index.html), except for its [Numba functionality](@ref knownissues).
+ArviZ.jl supports all of ArviZ's [API](https://python.arviz.org/en/latest/api/index.html), except for its [Numba functionality](@ref knownissues).
 See ArviZ's API documentation for details.
 
 ArviZ.jl wraps ArviZ's API functions and closely follows ArviZ's design.
@@ -49,7 +49,7 @@ Issues and pull requests are welcome.
 
 ## [Differences from ArviZ](@id differences)
 
-In ArviZ, functions in the [API](https://arviz-devs.github.io/arviz/api/index.html) are usually called with the package name prefix, (e.g. `arviz.plot_posterior`).
+In ArviZ, functions in the [API](https://python.arviz.org/en/latest/api/index.html) are usually called with the package name prefix, (e.g. `arviz.plot_posterior`).
 In ArviZ.jl, most of the [same functions](@ref api) are exported and therefore can be called without the prefix (e.g. `plot_posterior`).
 The exception are `from_xyz` converters for packages that have no (known) Julia wrappers.
 These functions are not exported to reduce namespace clutter.

--- a/docs/src/mpl_examples.md
+++ b/docs/src/mpl_examples.md
@@ -2,7 +2,7 @@
 
 !!! note
     
-    These examples are adapted from [ArviZ's matplotlib gallery](https://arviz-devs.github.io/arviz/examples/index.html#matplotlib).
+    These examples are adapted from [ArviZ's matplotlib gallery](https://python.arviz.org/en/latest/examples/index.html#matplotlib).
 
 ## Autocorrelation Plot
 

--- a/docs/src/quickstart.jl
+++ b/docs/src/quickstart.jl
@@ -35,7 +35,7 @@ md"""
 
 !!! note
     
-    This tutorial is adapted from [ArviZ's quickstart](https://arviz-devs.github.io/arviz/getting_started/Introduction.html).
+    This tutorial is adapted from [ArviZ's quickstart](https://python.arviz.org/en/latest/getting_started/Introduction.html).
 """
 
 # ╔═╡ d2eedd48-48c6-4fcd-b179-6be7fe68d3d6
@@ -166,7 +166,7 @@ md"""
 For much more powerful querying, analysis and plotting, we can use built-in ArviZ utilities to convert `Chains` objects to xarray datasets.
 Note we are also giving some information about labelling.
 
-ArviZ is built to work with [`InferenceData`](https://arviz-devs.github.io/ArviZ.jl/stable/reference/#ArviZ.InferenceData) (a netcdf datastore that loads data into `xarray` datasets), and the more *groups* it has access to, the more powerful analyses it can perform.
+ArviZ is built to work with [`InferenceData`](https://julia.arviz.org/stable/reference/#ArviZ.InferenceData) (a netcdf datastore that loads data into `xarray` datasets), and the more *groups* it has access to, the more powerful analyses it can perform.
 """
 
 # ╔═╡ 803efdd8-656e-4e37-ba36-81195d064972
@@ -179,7 +179,7 @@ idata_turing_post = from_mcmcchains(
 
 # ╔═╡ 79f342c8-0738-432b-bfd7-2da25e50fa91
 md"""
-Each group is an [`ArviZ.Dataset`](https://arviz-devs.github.io/ArviZ.jl/stable/reference/#ArviZ.Dataset) (a thinly wrapped `xarray.Dataset`).
+Each group is an [`ArviZ.Dataset`](https://julia.arviz.org/stable/reference/#ArviZ.Dataset) (a thinly wrapped `xarray.Dataset`).
 We can view a summary of the dataset.
 """
 
@@ -240,7 +240,7 @@ end;
 
 # ╔═╡ 4d2fdcbe-c1d4-43b6-b382-f2e956b952a1
 md"""
-And to extract the pointwise log-likelihoods, which is useful if you want to compute metrics such as [`loo`](https://arviz-devs.github.io/ArviZ.jl/stable/reference/#ArviZ.loo),
+And to extract the pointwise log-likelihoods, which is useful if you want to compute metrics such as [`loo`](https://julia.arviz.org/stable/reference/#ArviZ.loo),
 """
 
 # ╔═╡ 5a075722-232f-40fc-a499-8dc5b0c2424a
@@ -256,7 +256,7 @@ log_likelihood = let
 end;
 
 # ╔═╡ 1b5af2c3-f2ce-4e9d-9ad7-ac287a9178e2
-md"This can then be included in the [`from_mcmcchains`](https://arviz-devs.github.io/ArviZ.jl/stable/reference/#ArviZ.from_mcmcchains) call from above:"
+md"This can then be included in the [`from_mcmcchains`](https://julia.arviz.org/stable/reference/#ArviZ.from_mcmcchains) call from above:"
 
 # ╔═╡ b38c7a43-f00c-43c0-aa6b-9c581d6d0c73
 idata_turing = from_mcmcchains(
@@ -358,7 +358,7 @@ end
 # ╔═╡ ffc7730c-d861-48e8-b173-b03e0542f32b
 md"""
 Again, converting to `InferenceData`, we can get much richer labelling and mixing of data.
-Note that we're using the same [`from_cmdstan`](https://arviz-devs.github.io/ArviZ.jl/stable/reference/#ArviZ.from_cmdstan) function used by ArviZ to process cmdstan output files, but through the power of dispatch in Julia, if we pass a `Chains` object, it instead uses ArviZ.jl's overloads, which forward to `from_mcmcchains`.
+Note that we're using the same [`from_cmdstan`](https://julia.arviz.org/stable/reference/#ArviZ.from_cmdstan) function used by ArviZ to process cmdstan output files, but through the power of dispatch in Julia, if we pass a `Chains` object, it instead uses ArviZ.jl's overloads, which forward to `from_mcmcchains`.
 """
 
 # ╔═╡ 020cbdc0-a0a2-4d20-838f-c99b541d5832

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,7 +87,7 @@ convert_result(f, result, args...) = result
 load_backend(backend) = nothing
 
 function forwarddoc(f::Symbol)
-    return "See documentation for [`arviz.$(f)`](https://arviz-devs.github.io/arviz/api/generated/arviz.$(f).html)."
+    return "See documentation for [`arviz.$(f)`](https://python.arviz.org/en/latest/api/generated/arviz.$(f).html)."
 end
 
 forwardgetdoc(f::Symbol) = Docs.getdoc(getproperty(arviz, f))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,7 +87,7 @@ convert_result(f, result, args...) = result
 load_backend(backend) = nothing
 
 function forwarddoc(f::Symbol)
-    return "See documentation for [`arviz.$(f)`](https://python.arviz.org/en/latest/api/generated/arviz.$(f).html)."
+    return "See documentation for [`arviz.$(f)`](https://python.arviz.org/en/$(arviz_version())/api/generated/arviz.$(f).html)."
 end
 
 forwardgetdoc(f::Symbol) = Docs.getdoc(getproperty(arviz, f))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,7 +87,7 @@ convert_result(f, result, args...) = result
 load_backend(backend) = nothing
 
 function forwarddoc(f::Symbol)
-    return "See documentation for [`arviz.$(f)`](https://python.arviz.org/en/$(arviz_version())/api/generated/arviz.$(f).html)."
+    return "See documentation for [`arviz.$(f)`](https://python.arviz.org/en/latest/api/generated/arviz.$(f).html)."
 end
 
 forwardgetdoc(f::Symbol) = Docs.getdoc(getproperty(arviz, f))


### PR DESCRIPTION
This PR updates all links to `arviz.github.io/*` to point to the new `arviz.org` domain.