### PR TITLE
Convert arguments for ArviZ.compare

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.5.21"
+version = "0.5.22"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -13,6 +13,14 @@ for f in (:loo, :waic)
         end
     end
 end
+function convert_arguments(::typeof(compare), data, args...; kwargs...)
+    dict = Dict(k => try
+        topandas(Val(:ELPDData), v)
+    catch
+        convert_to_inference_data(v)
+    end for (k, v) in pairs(data))
+    return tuple(dict, args...), kwargs
+end
 
 convert_result(::typeof(loo), result) = todataframes(result)
 convert_result(::typeof(waic), result) = todataframes(result)

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -5,8 +5,13 @@ using DataFrames: DataFrames
 
     @testset "compare" begin
         idata2 = load_arviz_data("non_centered_eight")
-        df = compare(Dict("a" => idata, "b" => idata2))
+        model_dict = Dict("a" => idata, "b" => idata2)
+        loo_dict = Dict("a" => loo(idata), "b" => loo(idata2))
+        df = compare(model_dict)
         @test df isa DataFrames.DataFrame
+        df2 = compare(loo_dict)
+        @test df2 isa DataFrames.DataFrame
+        @test df == df2
     end
 
     @testset "hdi" begin


### PR DESCRIPTION
Fixes #183 by trying to convert values of the dict passed to `compare` to an `arviz.ELPDData`, and if that fails, converting to an `InferenceData`.