### PR TITLE
Deprecate bokeh backend

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,8 +37,7 @@ makedocs(;
         "Home" => "index.md",
         "Quickstart" => "quickstart.md",
         "API" => "api.md",
-        "Example Gallery" =>
-            ["Matplotlib" => "mpl_examples.md"],
+        "Example Gallery" => ["Matplotlib" => "mpl_examples.md"],
         "Reference" => "reference.md",
     ],
     checkdocs=:exports,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,7 @@ makedocs(;
         "Quickstart" => "quickstart.md",
         "API" => "api.md",
         "Example Gallery" =>
-            ["Matplotlib" => "mpl_examples.md", "Bokeh" => "bokeh_examples.md"],
+            ["Matplotlib" => "mpl_examples.md"],
         "Reference" => "reference.md",
     ],
     checkdocs=:exports,

--- a/docs/src/bokeh_examples.md
+++ b/docs/src/bokeh_examples.md
@@ -1,5 +1,0 @@
-# Bokeh Example Gallery
-
-!!! note
-    
-    See [ArviZ's bokeh gallery](https://python.arviz.org/en/latest/examples/index.html#bokeh) for examples.

--- a/src/bokeh.jl
+++ b/src/bokeh.jl
@@ -1,6 +1,7 @@
 const has_bokeh_png_deps = false
 
 function initialize_bokeh()
+    Base.depwarn("bokeh backend is deprecated and will be removed in a future release.")
     ispynull(bokeh) || return nothing
     try
         copy!(bokeh, _import_dependency("bokeh", "bokeh"; channel="conda-forge"))

--- a/src/bokeh.jl
+++ b/src/bokeh.jl
@@ -1,7 +1,9 @@
 const has_bokeh_png_deps = false
 
 function initialize_bokeh()
-    Base.depwarn("bokeh backend is deprecated and will be removed in a future release.")
+    Base.depwarn(
+        "backend=\"bokeh\" is deprecated; use backend=\"matplotlib\" instead.", :backend
+    )
     ispynull(bokeh) || return nothing
     try
         copy!(bokeh, _import_dependency("bokeh", "bokeh"; channel="conda-forge"))

--- a/test/test_backend.jl
+++ b/test/test_backend.jl
@@ -23,6 +23,7 @@ if !ispynull(ArviZ.bokeh) && "plot.backend" in keys(ArviZ.rcParams)
             backend = get(ArviZ.rcParams, "plot.backend", nothing)
             @test backend == "bokeh"
 
+            @test_deprecated plot_trace(idata)
             @test plot_trace(idata) isa ArviZ.BokehPlot
             @test plot_trace(idata; backend="matplotlib") isa Array{PyObject}
 


### PR DESCRIPTION
Relates #193. The backend still works, but we no longer document it, and it now raises a deprecation warning upon use.