### PR TITLE
Add fancy indexing of InferenceData

### DIFF
--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -65,14 +65,16 @@ using ArviZ, DimensionalData, Test
         @test Dimensions.index(idata_sel.posterior, :dimb) == [6]
         @test Dimensions.index(idata_sel.prior, :dimb) == [6]
 
-        idata_sel = idata[(:posterior, :observed_data), dimy=1, dimb=1, shared=At("s1")]
-        @test idata_sel isa InferenceData
-        @test ArviZ.groupnames(idata_sel) === (:posterior, :observed_data)
-        @test Dimensions.index(idata_sel.posterior, :dima) == coords.dima
-        @test Dimensions.index(idata_sel.posterior, :dimb) == coords.dimb[[1]]
-        @test Dimensions.index(idata_sel.posterior, :shared) == ["s1"]
-        @test Dimensions.index(idata_sel.observed_data, :dimy) == coords.dimy[[1]]
-        @test Dimensions.index(idata_sel.observed_data, :shared) == ["s1"]
+        if VERSION ≥ v"1.7"
+            idata_sel = idata[(:posterior, :observed_data), dimy=1, dimb=1, shared=At("s1")]
+            @test idata_sel isa InferenceData
+            @test ArviZ.groupnames(idata_sel) === (:posterior, :observed_data)
+            @test Dimensions.index(idata_sel.posterior, :dima) == coords.dima
+            @test Dimensions.index(idata_sel.posterior, :dimb) == coords.dimb[[1]]
+            @test Dimensions.index(idata_sel.posterior, :shared) == ["s1"]
+            @test Dimensions.index(idata_sel.observed_data, :dimy) == coords.dimy[[1]]
+            @test Dimensions.index(idata_sel.observed_data, :shared) == ["s1"]
+        end
 
         ds_sel = idata[:posterior, chain=1]
         @test ds_sel isa ArviZ.Dataset

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -56,6 +56,28 @@ using ArviZ, DimensionalData, Test
         @test idata[:prior] === prior
         @test idata[1] === posterior
         @test idata[2] === prior
+
+        idata_sel = idata[dima=At(2:3), dimb=At(6)]
+        @test idata_sel isa InferenceData
+        @test ArviZ.groupnames(idata_sel) === ArviZ.groupnames(idata)
+        @test Dimensions.index(idata_sel.posterior, :dima) == 2:3
+        @test Dimensions.index(idata_sel.prior, :dima) == 2:3
+        @test Dimensions.index(idata_sel.posterior, :dimb) == [6]
+        @test Dimensions.index(idata_sel.prior, :dimb) == [6]
+
+        idata_sel = idata[(:posterior, :observed_data), dimy=1, dimb=1, shared=At("s1")]
+        @test idata_sel isa InferenceData
+        @test ArviZ.groupnames(idata_sel) === (:posterior, :observed_data)
+        @test Dimensions.index(idata_sel.posterior, :dima) == coords.dima
+        @test Dimensions.index(idata_sel.posterior, :dimb) == coords.dimb[[1]]
+        @test Dimensions.index(idata_sel.posterior, :shared) == ["s1"]
+        @test Dimensions.index(idata_sel.observed_data, :dimy) == coords.dimy[[1]]
+        @test Dimensions.index(idata_sel.observed_data, :shared) == ["s1"]
+
+        ds_sel = idata[:posterior, chain=1]
+        @test ds_sel isa ArviZ.Dataset
+        @test !hasdim(ds_sel, :chain)
+
         idata2 = Base.setindex(idata, posterior, :warmup_posterior)
         @test keys(idata2) === (keys(idata)..., :warmup_posterior)
         @test idata2[:warmup_posterior] === posterior


### PR DESCRIPTION
This PR adds fancy indexing for `InferenceData` using `getindex` with keyword arguments. This offers similar functionality to xarray's `.sel` method.

Some examples:
```julia
julia> using ArviZ, DimensionalData

julia> idata = load_arviz_data("centered_eight");

julia> idata_sel = idata[school=At("Choate")]  # indexing all groups at once
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:school},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
InferenceData with groups:
  > posterior
  > posterior_predictive
  > sample_stats
  > prior
  > observed_data

julia> idata_sel.posterior
Dataset with dimensions: 
  Dim{:chain} Sampled 0:3 ForwardOrdered Regular Points,
  Dim{:draw} Sampled 0:499 ForwardOrdered Regular Points,
  Dim{:school} Categorical String[Choate] Unordered
and 3 layers:
  :mu    Float64 dims: Dim{:chain}, Dim{:draw} (4×500)
  :theta Float64 dims: Dim{:chain}, Dim{:draw}, Dim{:school} (4×500×1)
  :tau   Float64 dims: Dim{:chain}, Dim{:draw} (4×500)

with metadata OrderedCollections.OrderedDict{Symbol, Any} with 3 entries:
  :created_at                => "2019-06-21T17:36:34.398087"
  :inference_library_version => "3.7"
  :inference_library         => "pymc3"

with metadata OrderedCollections.OrderedDict{Symbol, Any} with 3 entries:
  :created_at                => "2019-06-21T17:36:34.398087"
  :inference_library_version => "3.7"
  :inference_library         => "pymc3"

julia> idata[(:posterior, :prior), chain=[1], draw=[1]]  # sub-setting groups while indexing
InferenceData with groups:
  > posterior
  > prior

julia> idata[:posterior, chain=[1], draw=[1]]  # indexing a single group
Dataset with dimensions: 
  Dim{:chain} Sampled Int64[0] ForwardOrdered Regular Points,
  Dim{:draw} Sampled Int64[0] ForwardOrdered Regular Points,
  Dim{:school} Categorical String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
and 3 layers:
  :mu    Float64 dims: Dim{:chain}, Dim{:draw} (1×1)
  :theta Float64 dims: Dim{:chain}, Dim{:draw}, Dim{:school} (1×1×8)
  :tau   Float64 dims: Dim{:chain}, Dim{:draw} (1×1)
```

The indices support DimensionalData's `Selector` objects or `IntervalSets`'s interval objects, so this allows other fancy indexing:

```julia
Dataset with dimensions: 
  Dim{:chain} Sampled 0:3 ForwardOrdered Regular Points,
  Dim{:draw} Sampled 0:499 ForwardOrdered Regular Points,
  Dim{:school} Categorical String[Phillips Andover, Phillips Exeter] Unordered
and 3 layers:
  :mu    Float64 dims: Dim{:chain}, Dim{:draw} (4×500)
  :theta Float64 dims: Dim{:chain}, Dim{:draw}, Dim{:school} (4×500×2)
  :tau   Float64 dims: Dim{:chain}, Dim{:draw} (4×500)

with metadata OrderedCollections.OrderedDict{Symbol, Any} with 3 entries:
  :created_at                => "2019-06-21T17:36:34.398087"
  :inference_library_version => "3.7"
  :inference_library         => "pymc3"

julia> DimensionalData.index(idata[draw=All((-Inf..5), (495..Inf))].posterior, :draw)
┌ Warning: (Dim{:draw},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
┌ Warning: (Dim{:draw},) dims were not found in object
└ @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/iopZH/src/Dimensions/primitives.jl:620
11-element Vector{Int64}:
   0
   1
   2
   3
   4
   5
 495
 496
 497
 498
 499
```