### PR TITLE
Simplify summarystats implementation

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -113,14 +113,14 @@ Compute summary statistics on `data`.
 ```@example summarystats
 using ArviZ
 idata = load_arviz_data("centered_eight")
-summarystats(idata; var_names=["mu", "tau"])
+summarystats(idata; var_names=(:mu, :tau))
 ```
 
 Other statistics can be calculated by passing a list of functions or a dictionary with key,
 function pairs:
 
 ```@example summarystats
-using StatsBase, Statistics
+using Statistics
 function median_sd(x)
     med = median(x)
     sd = sqrt(mean((x .- med).^2))
@@ -130,12 +130,12 @@ end
 func_dict = Dict(
     "std" => x -> std(x; corrected = false),
     "median_std" => median_sd,
-    "5%" => x -> percentile(x, 5),
+    "5%" => x -> quantile(x, 0.05),
     "median" => median,
-    "95%" => x -> percentile(x, 95),
+    "95%" => x -> quantile(x, 0.95),
 )
 
-summarystats(idata; var_names = ["mu", "tau"], stat_funcs = func_dict, extend = false)
+summarystats(idata; var_names = (:mu, :tau), stat_funcs = func_dict, extend = false)
 ```
 """
 function StatsBase.summarystats(data::InferenceData; group::Symbol=:posterior, kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,6 +9,7 @@ PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SampleChains = "754583d1-7fc4-4dab-93b5-5eaca5c9622e"
 SampleChainsDynamicHMC = "6d9fd711-e8b2-4778-9c70-c1dfb499d4c4"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]


### PR DESCRIPTION
This PR simplifies `summarystats` to support fewer options. This is in preparation for when we have our own native Julia `summarystats` implementation and will need more Julian approaches to deliver features like return type being a `Dataset` or a `DataFrame`.