### PR TITLE
Install scipy dependency from pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: Set LD_PRELOAD
-        run: echo "LD_PRELOAD=$HOME/.julia/conda/3/lib/libstdc++.so" >> $GITHUB_ENV
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -31,6 +31,7 @@ jobs:
           tar -xzpf ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}.tar.gz -C ${{ env.CMDSTAN_PATH }}
           make -C ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}/ build
         shell: bash
+      - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@v1
         env:
           JULIA_CMDSTAN_HOME: ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}/ # required by CmdStan.jl

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set LD_PRELOAD
-        run: echo "LD_PRELOAD=$HOME/.julia/conda/3/lib/libstdc++.so" >> $GITHUB_ENV
       - uses: julia-actions/setup-julia@v1
       - name: Cache CmdStan
         id: cache-cmdstan

--- a/.github/workflows/futures.yml
+++ b/.github/workflows/futures.yml
@@ -28,8 +28,6 @@ jobs:
             arviz_version: "release"
     steps:
       - uses: actions/checkout@v2
-      - name: Set LD_PRELOAD
-        run: echo "LD_PRELOAD=$HOME/.julia/conda/3/lib/libstdc++.so" >> $GITHUB_ENV
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.jl.*.cov
 *.jl.mem
 /deps/deps.jl
+/deps/build.log
 /docs/src/quickstart.md
 /docs/src/*.log
 /docs/src/assets/logo*.png

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,4 +2,4 @@ using PyCall
 
 # try to install scipy with pip if not yet installed
 # temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
-run(PyCall.python_cmd(`-m pip install --force-reinstall -- scipy`))
+run(PyCall.python_cmd(`-m pip install --force-reinstall --no-deps scipy`))

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,5 +3,5 @@ using Conda
 # try to install scipy with pip if not yet installed
 # temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
 Conda.pip_interop(true)
-Conda.pip("uninstall -y --no-deps", "scipy")
+Conda.pip("uninstall -y", "scipy")
 Conda.pip("install", "scipy")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,5 @@
+using PyCall
+
+# try to install scipy with pip if not yet installed
+# temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
+run(PyCall.python_cmd(`-m pip install --force-reinstall -- scipy`))

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,7 @@
-using PyCall
+using Conda
 
 # try to install scipy with pip if not yet installed
 # temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
-run(PyCall.python_cmd(`-m pip install --force-reinstall --no-deps scipy`))
+Conda.pip_interop(true)
+Conda.pip("uninstall -y --no-deps", "scipy")
+Conda.pip("install", "scipy")

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -109,6 +109,9 @@ const SUPPORTED_GROUPS_DICT = Dict{Symbol,Int}()
 
 include("setup.jl")
 
+# try to install scipy with pip if not yet installed
+# temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
+pyimport_conda("scipy", "scipy", "pypi")
 # Load ArviZ once at precompilation time for docstringS
 copy!(arviz, import_arviz())
 check_needs_update(; update=false)

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -109,9 +109,6 @@ const SUPPORTED_GROUPS_DICT = Dict{Symbol,Int}()
 
 include("setup.jl")
 
-# try to install scipy with pip if not yet installed
-# temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
-pyimport_conda("scipy", "scipy", "pypi")
 # Load ArviZ once at precompilation time for docstringS
 copy!(arviz, import_arviz())
 check_needs_update(; update=false)


### PR DESCRIPTION
This is an attempt at gracefully resolving #188 for new users by installing scipy from pypi instead of conda-forge. Existing users will already have scipy installed, so this won't help them.

This is necessary so that when registering a new version, the checker is able to import the package.