### PR TITLE
Fix Python dependency issues breaking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         julia-version: ["1.6", "1"]
         os: [ubuntu-latest]
         include:
-          - version: "1"
+          - julia-version: "1"
             os: windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       matrix:
         julia-version: ["1.6", "1"]
         os: [ubuntu-latest]
+        include:
+          - version: "1"
+            os: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           wget -P ${{ env.CMDSTAN_PATH }} https://github.com/stan-dev/cmdstan/releases/download/v${{ env.CMDSTAN_VERSION }}/cmdstan-${{ env.CMDSTAN_VERSION }}.tar.gz
           tar -xzpf ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}.tar.gz -C ${{ env.CMDSTAN_PATH }}
           make -C ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}/ build
-        shell: bash
       - uses: julia-actions/julia-buildpkg@latest
       - name: Install ArviZ dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
         with:
           path: ${{ env.CMDSTAN_PATH }}
           key: cmdstan-${{ env.CMDSTAN_VERSION }}-${{ runner.os }}
+      - name: Install wget for windows
+        if: matrix.os == 'windows-latest'
+        uses: crazy-max/ghaction-chocolatey@v2
+        with:
+          args: install wget
       - name: Download and build CmdStan
         if: steps.cache-cmdstan.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         include:
           - julia-version: "1"
             os: windows-latest
+          - julia-version: "1"
+            os: macOS-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,16 @@ env:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }}
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1.6", "1"]
-        os: [ubuntu-latest]
+        julia-version: ["1"]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         include:
-          - julia-version: "1"
-            os: windows-latest
-          - julia-version: "1"
-            os: macOS-latest
+          - julia-version: "1.6"
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,5 @@
 using Conda
 
-# try to install scipy with pip if not yet installed
 # temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
-Conda.pip_interop(true)
-Conda.pip("uninstall -y", "scipy")
-Conda.pip("install", "scipy")
+Conda.add("scipy<=1.8.0")
+Conda.add("matplotlib<3.6.0")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,6 @@
 using Conda
 
-# temporary workaround for https://github.com/arviz-devs/ArviZ.jl/issues/188
-Conda.add("scipy<=1.8.0")
-Conda.add("matplotlib<3.6.0")
+# temporary workaround for
+# - https://github.com/arviz-devs/ArviZ.jl/issues/188
+# - https://github.com/arviz-devs/arviz/issues/2120
+Conda.add(["matplotlib<3.6.0", "pandas<1.5.0", "scipy<=1.8.0"])

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -5,7 +5,7 @@ using ArviZ, DimensionalData, Test
     post = extract_dataset(idata, :posterior; combined=false)
     for k in keys(idata.posterior)
         @test haskey(post, k)
-        @test post[k] == idata.posterior[k]
+        @test post[k] ≈ idata.posterior[k]
         dims = DimensionalData.dims(post)
         dims_exp = DimensionalData.dims(idata.posterior)
         @test DimensionalData.name(dims) === DimensionalData.name(dims_exp)
@@ -14,7 +14,7 @@ using ArviZ, DimensionalData, Test
     prior = extract_dataset(idata, :prior; combined=false)
     for k in keys(idata.prior)
         @test haskey(prior, k)
-        @test prior[k] == idata.prior[k]
+        @test prior[k] ≈ idata.prior[k]
         dims = DimensionalData.dims(prior)
         dims_exp = DimensionalData.dims(idata.prior)
         @test DimensionalData.name(dims) === DimensionalData.name(dims_exp)

--- a/test/test_example_data.jl
+++ b/test/test_example_data.jl
@@ -54,7 +54,7 @@ using ArviZ, Test
         data = @test_deprecated load_arviz_data("centered_eight")
         datasets = @test_deprecated load_arviz_data()
         @test datasets isa Dict
-        mktempdir() do data_home
+        VERSION >= v"1.8" && mktempdir() do data_home
             @test_deprecated load_arviz_data("rugby", data_home)
             @test readdir(data_home) == ["rugby.nc"]
         end


### PR DESCRIPTION
Instead of pinning the scipy version upper bound using pip to work around #188, this uses Conda.jl, which will hopefully resolve the issue in #206. It also sets an upper bound to the version of matplotlib, since v3.6 currently causes our CI to error (could be a Python arviz error).