### PR TITLE
Remove upper bounds on Python dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 ArviZExampleData = "2f96bb34-afd9-46ae-bcd0-9b2d4372fe3c"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,0 @@
-using Conda
-
-# temporary workaround for
-# - https://github.com/arviz-devs/ArviZ.jl/issues/188
-# - https://github.com/arviz-devs/arviz/issues/2120
-Conda.add(["matplotlib<3.6.0", "pandas<1.5.0", "scipy<=1.8.0"])


### PR DESCRIPTION
On December 20th, CI began failing (see e.g. https://github.com/arviz-devs/ArviZ.jl/actions/runs/3736420397). It's not entirely clear why (as far as I can tell, no major Julia or Python dependencies had version changes between December 19th and 20th), but locally I found that if I removed the upper bounds we set on our Python dependencies (introduced in #234), then this particular issue went away.

This PR removes `deps/build.jl`, thus removing the Python version upper bounds.