### PR TITLE
Add examples with doctests to stats funs

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,2 @@
 style = "blue"
-format_docstrings = true
 pipe_to_function_call = false

--- a/src/ArviZStats/compare.jl
+++ b/src/ArviZStats/compare.jl
@@ -43,15 +43,14 @@ Compare the centered and non centered models of the eight school problem using t
 [`loo`](@ref) and [`Stacking`](@ref) weights:
 
 ```jldoctest compare; filter = [r"└.*"]
-using ArviZ, ArviZExampleData
-models = (
-    centered=load_example_data("centered_eight"),
-    non_centered=load_example_data("non_centered_eight"),
-)
-mc = compare(models)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> models = (
+           centered=load_example_data("centered_eight"),
+           non_centered=load_example_data("non_centered_eight"),
+       );
 
+julia> mc = compare(models)
 ┌ Warning: 1 parameters had Pareto shape values 0.7 < k ≤ 1. Resulting importance sampling estimates are likely to be unstable.
 └ @ PSIS ~/.julia/packages/PSIS/...
 ModelComparisonResult with Stacking weights
@@ -65,11 +64,9 @@ Compare the same models from pre-computed PSIS-LOO results and computing
 [`BootstrappedPseudoBMA`](@ref) weights:
 
 ```jldoctest compare; setup = :(using Random; Random.seed!(23))
-elpd_results = mc.elpd_result
-compare(elpd_results; weights_method=BootstrappedPseudoBMA())
+julia> elpd_results = mc.elpd_result;
 
-# output
-
+julia> compare(elpd_results; weights_method=BootstrappedPseudoBMA())
 ModelComparisonResult with BootstrappedPseudoBMA weights
          name  rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p   ⋯
  non_centered     1   -31        1.4          0               0     0.5  0.9   ⋯

--- a/src/ArviZStats/compare.jl
+++ b/src/ArviZStats/compare.jl
@@ -39,13 +39,42 @@ leading authorities on model comparison dx.doi.org/10.1111/1467-9868.00353
 
 # Examples
 
-```julia
+Compare the centered and non centered models of the eight school problem using the defaults:
+[`loo`](@ref) and [`Stacking`](@ref) weights:
+
+```jldoctest compare; filter = [r"└.*"]
 using ArviZ, ArviZExampleData
 models = (
     centered=load_example_data("centered_eight"),
     non_centered=load_example_data("non_centered_eight"),
 )
-mc = compare(models);
+mc = compare(models)
+
+# output
+
+┌ Warning: 1 parameters had Pareto shape values 0.7 < k ≤ 1. Resulting importance sampling estimates are likely to be unstable.
+└ @ PSIS ~/.julia/packages/PSIS/...
+ModelComparisonResult with Stacking weights
+         name  rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p   ⋯
+ non_centered     1   -31        1.4          0               0     1.0  0.9   ⋯
+     centered     2   -31        1.4       0.06           0.067     0.0  0.9   ⋯
+                                                                1 column omitted
+```
+
+Compare the same models from pre-computed PSIS-LOO results and computing
+[`BootstrappedPseudoBMA`](@ref) weights:
+
+```jldoctest compare; setup = :(using Random; Random.seed!(23))
+elpd_results = mc.elpd_result
+compare(elpd_results; weights_method=BootstrappedPseudoBMA())
+
+# output
+
+ModelComparisonResult with BootstrappedPseudoBMA weights
+         name  rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p   ⋯
+ non_centered     1   -31        1.4          0               0     0.5  0.9   ⋯
+     centered     2   -31        1.4       0.06           0.067     0.5  0.9   ⋯
+                                                                1 column omitted
 ```
 """
 function compare(

--- a/src/ArviZStats/hdi.jl
+++ b/src/ArviZStats/hdi.jl
@@ -42,8 +42,10 @@ julia> using ArviZ
 
 julia> x = randn(2_000);
 
-julia> hdi(x; prob=0.83)
-(lower = -1.3826605224220527, upper = 1.259817149822839)
+julia> hdi(x; prob=0.83) |> pairs
+pairs(::NamedTuple) with 2 entries:
+  :lower => -1.38266
+  :upper => 1.25982
 ```
 
 We can also calculate the HDI for a 3-dimensional array of samples:

--- a/src/ArviZStats/hdi.jl
+++ b/src/ArviZStats/hdi.jl
@@ -38,23 +38,20 @@ This implementation uses the algorithm of [^ChenShao1999].
 Here we calculate the 83% HDI for a normal random variable:
 
 ```jldoctest hdi; setup = :(using Random; Random.seed!(78))
-using ArviZ
-x = randn(2_000)
-hdi(x; prob=0.83)
+julia> using ArviZ
 
-# output
+julia> x = randn(2_000);
 
+julia> hdi(x; prob=0.83)
 (lower = -1.3826605224220527, upper = 1.259817149822839)
 ```
 
 We can also calculate the HDI for a 3-dimensional array of samples:
 
 ```jldoctest hdi; setup = :(using Random; Random.seed!(67))
-x = randn(1_000, 1, 1) .+ reshape(0:5:10, 1, 1, :)
-pairs(hdi(x))
+julia> x = randn(1_000, 1, 1) .+ reshape(0:5:10, 1, 1, :);
 
-# output
-
+julia> hdi(x) |> pairs
 pairs(::NamedTuple) with 2 entries:
   :lower => [-1.9674, 3.0326, 8.0326]
   :upper => [1.90028, 6.90028, 11.9003]
@@ -115,12 +112,11 @@ Calculate the highest density interval (HDI) for each parameter in the data.
 Calculate HDI for all parameters in the `posterior` group of an `InferenceData`:
 
 ```jldoctest hdi_infdata
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-hdi(idata)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> hdi(idata)
 Dataset with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered,
   Dim{:hdi_bound} Categorical{Symbol} Symbol[:lower, :upper] ForwardOrdered
@@ -133,10 +129,7 @@ and 3 layers:
 We can also calculate the HDI for a subset of variables:
 
 ```jldoctest hdi_infdata
-hdi(idata.posterior[(:theta,)]).theta
-
-# output
-
+julia> hdi(idata.posterior[(:theta,)]).theta
 8×2 DimArray{Float64,2} theta with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered,
   Dim{:hdi_bound} Categorical{Symbol} Symbol[:lower, :upper] ForwardOrdered

--- a/src/ArviZStats/hdi.jl
+++ b/src/ArviZStats/hdi.jl
@@ -110,7 +110,7 @@ end
 
 Calculate the highest density interval (HDI) for each parameter in the data.
 
-# Example
+# Examples
 
 Calculate HDI for all parameters in the `posterior` group of an `InferenceData`:
 

--- a/src/ArviZStats/loo.jl
+++ b/src/ArviZStats/loo.jl
@@ -61,14 +61,15 @@ See also: [`PSISLOOResult`](@ref), [`waic`](@ref)
 Manually compute ``R_\\mathrm{eff}`` and calculate PSIS-LOO of a model:
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :school))
-reff = ess(log_like; kind=:basic, split_chains=1, relative=true)
-loo(log_like; reff)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :school));
+
+julia> reff = ess(log_like; kind=:basic, split_chains=1, relative=true);
+
+julia> loo(log_like; reff)
 PSISLOOResult with estimates
        Estimate    SE
  elpd       -31   1.4
@@ -96,12 +97,11 @@ If more than one log-likelihood variable is present, then `var_name` must be pro
 Calculate PSIS-LOO of a model:
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-loo(idata)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> loo(idata)
 PSISLOOResult with estimates
        Estimate    SE
  elpd       -31   1.4

--- a/src/ArviZStats/loo.jl
+++ b/src/ArviZStats/loo.jl
@@ -55,6 +55,31 @@ See also: [`PSISLOOResult`](@ref), [`waic`](@ref)
     doi: [10.1007/s11222-016-9696-4](https://doi.org/10.1007/s11222-016-9696-4)
     arXiv: [1507.04544](https://arxiv.org/abs/1507.04544)
 [^LOOFAQ]: Aki Vehtari. Cross-validation FAQ. https://mc-stan.org/loo/articles/online-only/faq.html
+
+# Examples
+
+Manually compute ``R_\\mathrm{eff}`` and calculate PSIS-LOO of a model:
+
+```jldoctest
+using ArviZ, ArviZExampleData
+idata = load_example_data("centered_eight")
+log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :school))
+reff = ess(log_like; kind=:basic, split_chains=1, relative=true)
+loo(log_like; reff)
+
+# output
+
+PSISLOOResult with estimates
+       Estimate    SE
+ elpd       -31   1.4
+    p       0.9  0.34
+
+and PSISResult with 500 draws, 4 chains, and 8 parameters
+Pareto shape (k) diagnostic values:
+                    Count      Min. ESS
+ (-Inf, 0.5]  good  7 (87.5%)  151
+  (0.5, 0.7]  okay  1 (12.5%)  446
+```
 """
 loo(ll::AbstractArray; kwargs...) = _loo(ll; kwargs...)
 
@@ -65,6 +90,29 @@ loo(ll::AbstractArray; kwargs...) = _loo(ll; kwargs...)
 Compute PSIS-LOO from log-likelihood values in `data`.
 
 If more than one log-likelihood variable is present, then `var_name` must be provided.
+
+# Examples
+
+Calculate PSIS-LOO of a model:
+
+```jldoctest
+using ArviZ, ArviZExampleData
+idata = load_example_data("centered_eight")
+loo(idata)
+
+# output
+
+PSISLOOResult with estimates
+       Estimate    SE
+ elpd       -31   1.4
+    p       0.9  0.34
+
+and PSISResult with 500 draws, 4 chains, and 8 parameters
+Pareto shape (k) diagnostic values:
+                    Count      Min. ESS
+ (-Inf, 0.5]  good  6 (75.0%)  135
+  (0.5, 0.7]  okay  2 (25.0%)  421
+```
 """
 function loo(
     data::Union{InferenceObjects.InferenceData,InferenceObjects.Dataset};

--- a/src/ArviZStats/loo_pit.jl
+++ b/src/ArviZStats/loo_pit.jl
@@ -39,6 +39,7 @@ LOO-PIT values should be approximately uniformly distributed on ``[0, 1]``.[^Gab
     J. R. Stat. Soc. Ser. A Stat. Soc. 182, 389–402 (2019).
     doi: [10.1111/rssa.12378](https://doi.org/10.1111/rssa.12378)
     arXiv: [1709.01449](https://arxiv.org/abs/1709.01449)
+
 # Examples
 
 Calculate LOO-PIT values using as test quantity the observed values themselves.

--- a/src/ArviZStats/loo_pit.jl
+++ b/src/ArviZStats/loo_pit.jl
@@ -45,17 +45,17 @@ LOO-PIT values should be approximately uniformly distributed on ``[0, 1]``.[^Gab
 Calculate LOO-PIT values using as test quantity the observed values themselves.
 
 ```jldoctest loo_pit1
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-log_weights = loo(idata; var_name=:obs).psis_result.log_weights
-loo_pit(
-    idata.observed_data.obs,
-    permutedims(idata.posterior_predictive.obs, (:draw, :chain, :school)),
-    log_weights,
-)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> log_weights = loo(idata; var_name=:obs).psis_result.log_weights;
+
+julia> loo_pit(
+            idata.observed_data.obs,
+            permutedims(idata.posterior_predictive.obs, (:draw, :chain, :school)),
+            log_weights,
+        )
 8-element DimArray{Float64,1} with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
  "Choate"            0.943511
@@ -72,16 +72,16 @@ Calculate LOO-PIT values using as test quantity the square of the difference bet
 each observation and `mu`.
 
 ```jldoctest loo_pit1
-using DimensionalData, Statistics
-T = idata.observed_data.obs .- only(median(idata.posterior.mu; dims=(:draw, :chain)))
-T_pred = permutedims(
-    broadcast_dims(-, idata.posterior_predictive.obs, idata.posterior.mu),
-    (:draw, :chain, :school),
-)
-loo_pit(T .^ 2, T_pred .^ 2, log_weights)
+julia> using DimensionalData, Statistics
 
-# output
+julia> T = idata.observed_data.obs .- only(median(idata.posterior.mu; dims=(:draw, :chain)));
 
+julia> T_pred = permutedims(
+           broadcast_dims(-, idata.posterior_predictive.obs, idata.posterior.mu),
+           (:draw, :chain, :school),
+       );
+
+julia> loo_pit(T .^ 2, T_pred .^ 2, log_weights)
 8-element DimArray{Float64,1} with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
  "Choate"            0.873577
@@ -140,13 +140,13 @@ Compute LOO-PIT values using existing normalized log LOO importance weights.
 Calculate LOO-PIT values using already computed log weights.
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-loo_result = loo(idata; var_name=:obs)
-loo_pit(idata, loo_result.psis_result.log_weights; y_name=:obs)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> loo_result = loo(idata; var_name=:obs);
+
+julia> loo_pit(idata, loo_result.psis_result.log_weights; y_name=:obs)
 8-element DimArray{Float64,1} loo_pit_obs with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
  "Choate"            0.943511
@@ -199,12 +199,11 @@ See also: [`loo`](@ref), [`psis`](@ref)
 Calculate LOO-PIT values using as test quantity the observed values themselves.
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-loo_pit(idata; y_name=:obs)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> loo_pit(idata; y_name=:obs)
 8-element DimArray{Float64,1} loo_pit_obs with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
  "Choate"            0.943511

--- a/src/ArviZStats/model_weights.jl
+++ b/src/ArviZStats/model_weights.jl
@@ -36,29 +36,30 @@ See also: [`AbstractModelWeightsMethod`](@ref), [`compare`](@ref)
 Compute [`Stacking`](@ref) weights for two models:
 
 ```jldoctest model_weights; filter = [r"└.*"]
-using ArviZ, ArviZExampleData
-models = (
-    centered=load_example_data("centered_eight"),
-    non_centered=load_example_data("non_centered_eight"),
-)
-elpd_results = map(loo, models)
-model_weights(elpd_results; method=Stacking())
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> models = (
+           centered=load_example_data("centered_eight"),
+           non_centered=load_example_data("non_centered_eight"),
+       );
 
+julia> elpd_results = map(loo, models);
 ┌ Warning: 1 parameters had Pareto shape values 0.7 < k ≤ 1. Resulting importance sampling estimates are likely to be unstable.
 └ @ PSIS ~/.julia/packages/PSIS/...
-(centered = 5.341753943391326e-19, non_centered = 1.0)
+
+julia> model_weights(elpd_results; method=Stacking()) |> pairs
+pairs(::NamedTuple) with 2 entries:
+  :centered     => 5.34175e-19
+  :non_centered => 1.0
 ```
 
 Now we compute [`BootstrappedPseudoBMA`](@ref) weights for the same models:
 
 ```jldoctest model_weights; setup = :(using Random; Random.seed!(94))
-model_weights(elpd_results; method=BootstrappedPseudoBMA())
-
-# output
-
-(centered = 0.4837232110116756, non_centered = 0.5162767889883245)
+julia> model_weights(elpd_results; method=BootstrappedPseudoBMA()) |> pairs
+pairs(::NamedTuple) with 2 entries:
+  :centered     => 0.483723
+  :non_centered => 0.516277
 ```
 """
 function model_weights(elpd_results; method::AbstractModelWeightsMethod=Stacking())

--- a/src/ArviZStats/model_weights.jl
+++ b/src/ArviZStats/model_weights.jl
@@ -32,14 +32,32 @@ See also: [`AbstractModelWeightsMethod`](@ref), [`compare`](@ref)
     arXiv: [1704.02030](https://arxiv.org/abs/1704.02030)
 # Examples
 
-```jldoctest
+Compute [`Stacking`](@ref) weights for two models:
+
+```jldoctest model_weights; filter = [r"└.*"]
 using ArviZ, ArviZExampleData
 models = (
     centered=load_example_data("centered_eight"),
     non_centered=load_example_data("non_centered_eight"),
 )
 elpd_results = map(loo, models)
-model_weights(elpd_results);
+model_weights(elpd_results; method=Stacking())
+
+# output
+
+┌ Warning: 1 parameters had Pareto shape values 0.7 < k ≤ 1. Resulting importance sampling estimates are likely to be unstable.
+└ @ PSIS ~/.julia/packages/PSIS/...
+(centered = 5.341753943391326e-19, non_centered = 1.0)
+```
+
+Now we compute [`BootstrappedPseudoBMA`](@ref) weights for the same models:
+
+```jldoctest model_weights; setup = :(using Random; Random.seed!(94))
+model_weights(elpd_results; method=BootstrappedPseudoBMA())
+
+# output
+
+(centered = 0.4837232110116756, non_centered = 0.5162767889883245)
 ```
 """
 function model_weights(elpd_results; method::AbstractModelWeightsMethod=Stacking())

--- a/src/ArviZStats/model_weights.jl
+++ b/src/ArviZStats/model_weights.jl
@@ -30,6 +30,7 @@ See also: [`AbstractModelWeightsMethod`](@ref), [`compare`](@ref)
     2018. Bayesian Analysis. 13, 3, 917–1007.
     doi: [10.1214/17-BA1091](https://doi.org/10.1214/17-BA1091)
     arXiv: [1704.02030](https://arxiv.org/abs/1704.02030)
+
 # Examples
 
 Compute [`Stacking`](@ref) weights for two models:

--- a/src/ArviZStats/r2_score.jl
+++ b/src/ArviZStats/r2_score.jl
@@ -12,6 +12,7 @@
     R-squared for Bayesian Regression Models, The American Statistician,
     73:3, 307-9,
     DOI: [10.1080/00031305.2018.1549100](https://doi.org/10.1080/00031305.2018.1549100).
+
 # Examples
 
 ```jldoctest

--- a/src/ArviZStats/r2_score.jl
+++ b/src/ArviZStats/r2_score.jl
@@ -16,15 +16,18 @@
 # Examples
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("regression1d")
-y_true = idata.observed_data.y
-y_pred = PermutedDimsArray(idata.posterior_predictive.y, (:draw, :chain, :y_dim_0))
-r2_score(y_true, y_pred)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("regression1d");
 
-(r2 = 0.683196996216511, r2_std = 0.036883777654323734)
+julia> y_true = idata.observed_data.y;
+
+julia> y_pred = PermutedDimsArray(idata.posterior_predictive.y, (:draw, :chain, :y_dim_0));
+
+julia> r2_score(y_true, y_pred) |> pairs
+pairs(::NamedTuple) with 2 entries:
+  :r2     => 0.683197
+  :r2_std => 0.0368838
 ```
 """
 function r2_score(y_true, y_pred)
@@ -47,13 +50,14 @@ Compute ``R²`` from `idata`, automatically formatting the predictions to the co
 # Examples
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("regression10d")
-r2_score(idata)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("regression10d");
 
-(r2 = 0.998384805658226, r2_std = 0.00010062063385452256)
+julia> r2_score(idata) |> pairs
+pairs(::NamedTuple) with 2 entries:
+  :r2     => 0.998385
+  :r2_std => 0.000100621
 ```
 """
 function r2_score(

--- a/src/ArviZStats/waic.jl
+++ b/src/ArviZStats/waic.jl
@@ -47,13 +47,13 @@ See also: [`WAICResult`](@ref), [`loo`](@ref)
 Calculate WAIC of a model:
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :school))
-waic(log_like)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :school));
+
+julia> waic(log_like)
 WAICResult with estimates
        Estimate    SE
  elpd       -31   1.4
@@ -75,12 +75,11 @@ If more than one log-likelihood variable is present, then `var_name` must be pro
 Calculate WAIC of a model:
 
 ```jldoctest
-using ArviZ, ArviZExampleData
-idata = load_example_data("centered_eight")
-waic(idata)
+julia> using ArviZ, ArviZExampleData
 
-# output
+julia> idata = load_example_data("centered_eight");
 
+julia> waic(idata)
 WAICResult with estimates
        Estimate    SE
  elpd       -31   1.4

--- a/src/ArviZStats/waic.jl
+++ b/src/ArviZStats/waic.jl
@@ -41,6 +41,24 @@ See also: [`WAICResult`](@ref), [`loo`](@ref)
     doi: [10.1007/s11222-016-9696-4](https://doi.org/10.1007/s11222-016-9696-4)
     arXiv: [1507.04544](https://arxiv.org/abs/1507.04544)
 [^LOOFAQ]: Aki Vehtari. Cross-validation FAQ. https://mc-stan.org/loo/articles/online-only/faq.html
+
+# Examples
+
+Calculate WAIC of a model:
+
+```jldoctest
+using ArviZ, ArviZExampleData
+idata = load_example_data("centered_eight")
+log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :school))
+waic(log_like)
+
+# output
+
+WAICResult with estimates
+       Estimate    SE
+ elpd       -31   1.4
+    p       0.9  0.33
+```
 """
 waic(ll::AbstractArray) = _waic(ll)
 
@@ -51,6 +69,23 @@ waic(ll::AbstractArray) = _waic(ll)
 Compute WAIC from log-likelihood values in `data`.
 
 If more than one log-likelihood variable is present, then `var_name` must be provided.
+
+# Examples
+
+Calculate WAIC of a model:
+
+```jldoctest
+using ArviZ, ArviZExampleData
+idata = load_example_data("centered_eight")
+waic(idata)
+
+# output
+
+WAICResult with estimates
+       Estimate    SE
+ elpd       -31   1.4
+    p       0.9  0.33
+```
 """
 function waic(
     data::Union{InferenceObjects.InferenceData,InferenceObjects.Dataset};


### PR DESCRIPTION
This PR adds examples with doctests for `loo`, `waic`, `model_weights`, and `compare`.