### PR TITLE
Implement summarystats for InferenceObjects types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"

--- a/docs/src/api/stats.md
+++ b/docs/src/api/stats.md
@@ -4,6 +4,13 @@
 Pages = ["stats.md"]
 ```
 
+## Summary statistics
+
+```@docs
+SummaryStats
+summarystats
+```
+
 ## General statistics
 
 ```@docs

--- a/src/ArviZ.jl
+++ b/src/ArviZ.jl
@@ -22,7 +22,6 @@ import Base:
     +
 import Base.Docs: getdoc
 using StatsBase: StatsBase
-import StatsBase: summarystats
 import Markdown: @doc_str
 
 using InferenceObjects
@@ -48,6 +47,7 @@ export PSIS, PSISResult, psis, psis!
 export elpd_estimates, information_criterion, loo, waic
 export AbstractModelWeightsMethod, BootstrappedPseudoBMA, PseudoBMA, Stacking, model_weights
 export ModelComparisonResult, compare
+export SummaryStats, summarystats
 export hdi, hdi!, loo_pit, r2_score
 
 ## Diagnostics

--- a/src/ArviZStats/ArviZStats.jl
+++ b/src/ArviZStats/ArviZStats.jl
@@ -18,7 +18,7 @@ using PSIS: PSIS, PSISResult, psis, psis!
 using Random: Random
 using Setfield: Setfield
 using Statistics: Statistics
-using StatsBase: StatsBase
+using StatsBase: StatsBase, summarystats
 using Tables: Tables
 using TableTraits: TableTraits
 
@@ -32,6 +32,9 @@ export elpd_estimates, information_criterion, loo, waic
 # Model weighting and comparison
 export AbstractModelWeightsMethod, BootstrappedPseudoBMA, PseudoBMA, Stacking, model_weights
 export ModelComparisonResult, compare
+
+# Summary statistics
+export SummaryStats, summarystats
 
 # Others
 export hdi, hdi!, loo_pit, r2_score
@@ -50,5 +53,6 @@ include("model_weights.jl")
 include("compare.jl")
 include("loo_pit.jl")
 include("r2_score.jl")
+include("summarystats.jl")
 
 end  # module

--- a/src/ArviZStats/ArviZStats.jl
+++ b/src/ArviZStats/ArviZStats.jl
@@ -42,6 +42,7 @@ export hdi, hdi!, loo_pit, r2_score
 # load for docstrings
 using ArviZ: InferenceData, convert_to_dataset, ess
 
+const DEFAULT_INTERVAL_PROB = 0.94
 const INFORMATION_CRITERION_SCALES = (deviance=-2, log=1, negative_log=-1)
 
 include("utils.jl")

--- a/src/ArviZStats/compare.jl
+++ b/src/ArviZStats/compare.jl
@@ -202,6 +202,8 @@ function Tables.getcolumn(r::ModelComparisonResult, nm::Symbol)
     end
     throw(ArgumentError("Unrecognized column name $nm"))
 end
+Tables.rowaccess(::Type{<:ModelComparisonResult}) = true
+Tables.rows(r::ModelComparisonResult) = Tables.rows(Tables.columntable(r))
 
 IteratorInterfaceExtensions.isiterable(::ModelComparisonResult) = true
 function IteratorInterfaceExtensions.getiterator(r::ModelComparisonResult)

--- a/src/ArviZStats/compare.jl
+++ b/src/ArviZStats/compare.jl
@@ -156,7 +156,7 @@ end
 function _show(io::IO, mime::MIME, r::ModelComparisonResult; kwargs...)
     row_labels = collect(r.name)
     cols = Tables.columnnames(r)[2:end]
-    table = Tables.columntable(r)[cols]
+    table = NamedTuple{cols}(Tables.columntable(r))
 
     weights_method_name = _typename(r.weights_method)
     weights = table.weight

--- a/src/ArviZStats/compare.jl
+++ b/src/ArviZStats/compare.jl
@@ -149,6 +149,9 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", r::ModelComparisonResult; kwargs...)
     return _show(io, mime, r; kwargs...)
 end
+function Base.show(io::IO, mime::MIME"text/html", r::ModelComparisonResult; kwargs...)
+    return _show(io, mime, r; kwargs...)
+end
 
 function _show(io::IO, mime::MIME, r::ModelComparisonResult; kwargs...)
     row_labels = collect(r.name)

--- a/src/ArviZStats/elpdresult.jl
+++ b/src/ArviZStats/elpdresult.jl
@@ -13,26 +13,12 @@ Subtypes implement the following functions:
 """
 abstract type AbstractELPDResult end
 
-function _print_elpd_estimates(
-    io::IO, ::MIME"text/plain", r::AbstractELPDResult; sigdigits_se=2
+function _show_elpd_estimates(
+    io::IO, mime::MIME"text/plain", r::AbstractELPDResult; kwargs...
 )
     estimates = elpd_estimates(r)
     table = map(Base.vect, NamedTuple{(:elpd, :elpd_mcse, :p, :p_mcse)}(estimates))
-    formatters = (
-        ft_printf_sigdigits_matching_se(table.elpd_mcse, [1]),
-        ft_printf_sigdigits_matching_se(table.p_mcse, [3]),
-        ft_printf_sigdigits(sigdigits_se),
-    )
-
-    PrettyTables.pretty_table(
-        io,
-        table;
-        show_subheader=false,
-        hlines=:none,
-        vlines=:none,
-        formatters,
-        newline_at_end=false,
-    )
+    _show_prettytable(io, mime, table; kwargs...)
     return nothing
 end
 

--- a/src/ArviZStats/elpdresult.jl
+++ b/src/ArviZStats/elpdresult.jl
@@ -17,18 +17,17 @@ function _print_elpd_estimates(
     io::IO, ::MIME"text/plain", r::AbstractELPDResult; sigdigits_se=2
 )
     estimates = elpd_estimates(r)
-    elpd, elpd_mcse = estimates.elpd, estimates.elpd_mcse
-    p, p_mcse = estimates.p, estimates.p_mcse
-    table = (; Estimate=[elpd, p], SE=[elpd_mcse, p_mcse])
-    formatters = function (v, i, j)
-        sigdigits = j == 1 ? sigdigits_matching_error(v, table.SE[i]) : sigdigits_se
-        return sprint(Printf.format, Printf.Format("%.$(sigdigits)g"), v)
-    end
+    table = map(Base.vect, NamedTuple{(:elpd, :elpd_mcse, :p, :p_mcse)}(estimates))
+    formatters = (
+        ft_printf_sigdigits_matching_se(table.elpd_mcse, [1]),
+        ft_printf_sigdigits_matching_se(table.p_mcse, [3]),
+        ft_printf_sigdigits(sigdigits_se),
+    )
+
     PrettyTables.pretty_table(
         io,
         table;
         show_subheader=false,
-        row_labels=["elpd", "p"],
         hlines=:none,
         vlines=:none,
         formatters,

--- a/src/ArviZStats/hdi.jl
+++ b/src/ArviZStats/hdi.jl
@@ -1,11 +1,10 @@
-const HDI_DEFAULT_PROB = 0.94
 # this pattern ensures that the type is completely specified at compile time
 const HDI_BOUND_DIM = Dimensions.format(
     Dimensions.Dim{:hdi_bound}([:lower, :upper]), Base.OneTo(2)
 )
 
 """
-    hdi(samples::AbstractArray{<:Real}; prob=$(HDI_DEFAULT_PROB)) -> (; lower, upper)
+    hdi(samples::AbstractArray{<:Real}; prob=$(DEFAULT_INTERVAL_PROB)) -> (; lower, upper)
 
 Estimate the unimodal highest density interval (HDI) of `samples` for the probability `prob`.
 
@@ -20,8 +19,8 @@ This implementation uses the algorithm of [^ChenShao1999].
 
 !!! note
     Any default value of `prob` is arbitrary. The default value of
-    `prob=$(HDI_DEFAULT_PROB)` instead of a more common default like `prob=0.95` is chosen
-    to reminder the user of this arbitrariness.
+    `prob=$(DEFAULT_INTERVAL_PROB)` instead of a more common default like `prob=0.95` is
+    chosen to reminder the user of this arbitrariness.
 
 [^Hyndman1996]: Rob J. Hyndman (1996) Computing and Graphing Highest Density Regions,
                 Amer. Stat., 50(2): 120-6.
@@ -66,11 +65,11 @@ function hdi(x::AbstractArray{<:Real}; kwargs...)
 end
 
 """
-    hdi!(samples::AbstractArray{<:Real}; prob=$(HDI_DEFAULT_PROB)) -> (; lower, upper)
+    hdi!(samples::AbstractArray{<:Real}; prob=$(DEFAULT_INTERVAL_PROB)) -> (; lower, upper)
 
 A version of [hdi](@ref) that sorts `samples` in-place while computing the HDI.
 """
-function hdi!(x::AbstractArray{<:Real}; prob::Real=HDI_DEFAULT_PROB)
+function hdi!(x::AbstractArray{<:Real}; prob::Real=DEFAULT_INTERVAL_PROB)
     0 < prob < 1 || throw(DomainError(prob, "HDI `prob` must be in the range `(0, 1)`.]"))
     return _hdi!(x, prob)
 end
@@ -104,8 +103,8 @@ function _hdi!(x::AbstractArray{<:Real}, prob::Real)
 end
 
 """
-    hdi(data::InferenceData; prob=$HDI_DEFAULT_PROB) -> Dataset
-    hdi(data::Dataset; prob=$HDI_DEFAULT_PROB) -> Dataset
+    hdi(data::InferenceData; prob=$DEFAULT_INTERVAL_PROB) -> Dataset
+    hdi(data::Dataset; prob=$DEFAULT_INTERVAL_PROB) -> Dataset
 
 Calculate the highest density interval (HDI) for each parameter in the data.
 

--- a/src/ArviZStats/loo.jl
+++ b/src/ArviZStats/loo.jl
@@ -20,9 +20,8 @@ function elpd_estimates(r::PSISLOOResult; pointwise::Bool=false)
     return pointwise ? r.pointwise : r.estimates
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", result::PSISLOOResult)
-    println(io, "PSISLOOResult with estimates")
-    _print_elpd_estimates(io, mime, result)
+function Base.show(io::IO, mime::MIME"text/plain", result::PSISLOOResult; kwargs...)
+    _show_elpd_estimates(io, mime, result; title="PSISLOOResult with estimates", kwargs...)
     println(io)
     println(io)
     print(io, "and ")

--- a/src/ArviZStats/loo.jl
+++ b/src/ArviZStats/loo.jl
@@ -71,9 +71,8 @@ julia> reff = ess(log_like; kind=:basic, split_chains=1, relative=true);
 
 julia> loo(log_like; reff)
 PSISLOOResult with estimates
-       Estimate    SE
- elpd       -31   1.4
-    p       0.9  0.34
+ elpd  elpd_mcse    p  p_mcse
+  -31        1.4  0.9    0.34
 
 and PSISResult with 500 draws, 4 chains, and 8 parameters
 Pareto shape (k) diagnostic values:
@@ -103,9 +102,8 @@ julia> idata = load_example_data("centered_eight");
 
 julia> loo(idata)
 PSISLOOResult with estimates
-       Estimate    SE
- elpd       -31   1.4
-    p       0.9  0.34
+ elpd  elpd_mcse    p  p_mcse
+  -31        1.4  0.9    0.34
 
 and PSISResult with 500 draws, 4 chains, and 8 parameters
 Pareto shape (k) diagnostic values:

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -86,6 +86,8 @@ function Base.show(
     return nothing
 end
 
+_is_ess_label(k::Symbol) = ((k === :ess) || startswith(string(k), "ess_"))
+
 #### Tables interface as column table
 
 Tables.istable(::Type{<:SummaryStats}) = true

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -1,12 +1,15 @@
 """
-    SummaryStats{D}
+$(SIGNATURES)
 
 A container for a column table of values computed by [`summarystats`](@ref).
 
-The first column is `variable`, and all remaining columns are the summary statistics.
 This object implements the Tables and TableTraits interfaces and has a custom `show` method.
+
+$(FIELDS)
 """
-struct SummaryStats{D}
+struct SummaryStats{D<:NamedTuple}
+    """The summary statistics for each variable, with the first entry containing the
+    variable names"""
     data::D
 end
 
@@ -113,15 +116,15 @@ Compute summary statistics and diagnostics on the `data`.
 # Keywords
 
   - `return_type::Type`: The type of object to return. Valid options are [`Dataset`](@ref)
-  and [`SummaryStats`](@ref). Defaults to `SummaryStats`.
-  - `prob_interval::Real`: The value of the `prob` argument to [`hdi`](@ref) used to compute the
-  highest density interval. Defaults to $(DEFAULT_INTERVAL_PROB).
+    and [`SummaryStats`](@ref). Defaults to `SummaryStats`.
+  - `prob_interval::Real`: The value of the `prob` argument to [`hdi`](@ref) used to compute
+    the highest density interval. Defaults to $(DEFAULT_INTERVAL_PROB).
   - `metric_dim`: The dimension name or type to use for the computed metrics. Only specify
-  if `return_type` is `Dataset`. Defaults to `Dim{_:metric}`.
+    if `return_type` is `Dataset`. Defaults to `Dim{_:metric}`.
   - `compact_labels::Bool`: Whether to use compact names for the variables. Only used if
-  `return_type` is `SummaryStats`. Defaults to `true`.
+    `return_type` is `SummaryStats`. Defaults to `true`.
   - `kind::Symbol`: Whether to compute just statistics (`:stats`), just diagnostics
-  (`:diagnostics`), or both (`:both`). Defaults to `:both`.
+    (`:diagnostics`), or both (`:both`). Defaults to `:both`.
 
 # Examples
 

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -24,7 +24,12 @@ function Base.iterate(stats::SummaryStats, i::Int=firstindex(parent(stats)))
 end
 
 function Base.show(
-    io::IO, stats::SummaryStats; sigdigits_se=2, sigdigits_default=3, kwargs...
+    io::IO,
+    ::MIME"text/plain",
+    stats::SummaryStats;
+    sigdigits_se=2,
+    sigdigits_default=3,
+    kwargs...,
 )
     # formatting functions for special columns
     # see https://ronisbr.github.io/PrettyTables.jl/stable/man/formatters/
@@ -57,17 +62,17 @@ function Base.show(
         i => :r for (i, k) in enumerate(keys(stats)) if _is_ess_label(k)
     )
 
+    # TODO: highlight bad values in the REPL
+
     kwargs_new = merge(
         (
-            title="SummaryStatistics",
+            title="SummaryStats",
+            title_crayon=PrettyTables.Crayon(),
+            header=["", Iterators.drop(keys(stats), 1)...],  # drop "variable" from header
             show_subheader=false,
             hlines=:none,
             vlines=:none,
-            formatters,
             newline_at_end=false,
-            alignment=[:l, fill(:r, length(colnames) - 1)...],
-            header=["", colnames[2:end]...],
-            title_crayon=PrettyTables.Crayon(),
             formatters=Tuple(formatters),
             alignment,
             alignment_anchor_regex,
@@ -76,7 +81,8 @@ function Base.show(
         ),
         kwargs,
     )
-    PrettyTables.pretty_table(io, stats.data; kwargs_new...)
+    PrettyTables.pretty_table(io, stats; kwargs_new...)
+
     return nothing
 end
 

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -119,12 +119,12 @@ SummaryStatistics
  tau                      4.12   3.1   0.896     9.67
 ```
 """
-function summarystats(
+function StatsBase.summarystats(
     data::InferenceObjects.InferenceData; group::Symbol=:posterior, kwargs...
 )
     return summarystats(data[group]; kwargs...)
 end
-function summarystats(
+function StatsBase.summarystats(
     data::InferenceObjects.Dataset; return_type::Type=SummaryStats, kwargs...
 )
     return _summarize(return_type, data; kwargs...)
@@ -222,19 +222,4 @@ function _indices_to_name(name, dims, compact)
         end
     end
     return "$name[" * join(elements, ',') * "]"
-end
-
-"""
-    summarystats(data::InferenceData; group=:posterior, kwargs...)
-    summarystats(data::Dataset; kwargs...)
-
-Compute summary statistics on `data`.
-
-These methods simply forward to [`summarize`](@ref). See that docstring for details.
-"""
-function StatsBase.summarystats(data::InferenceObjects.InferenceData; kwargs...)
-    return summarize(data; kwargs...)
-end
-function StatsBase.summarystats(data::InferenceObjects.Dataset; kwargs...)
-    return summarize(data; kwargs...)
 end

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -38,7 +38,7 @@ function Base.show(io::IO, mime::MIME"text/html", stats::SummaryStats; kwargs...
 end
 
 function _show(io::IO, mime::MIME, stats::SummaryStats; kwargs...)
-    data = parent(stats)[eachindex(stats)[2:end]]
+    data = NamedTuple{eachindex(stats)[2:end]}(parent(stats))
     rhat_formatter = _prettytables_rhat_formatter(data)
     extra_formatters = rhat_formatter === nothing ? () : (rhat_formatter,)
     return _show_prettytable(

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -117,8 +117,6 @@ Compute summary statistics and diagnostics on the `data`.
 
 # Keywords
 
-  - `return_type::Type`: The type of object to return. Valid options are [`Dataset`](@ref)
-    and [`SummaryStats`](@ref). Defaults to `SummaryStats`.
   - `prob_interval::Real`: The value of the `prob` argument to [`hdi`](@ref) used to compute
     the highest density interval. Defaults to $(DEFAULT_INTERVAL_PROB).
   - `return_type::Type`: The type of object to return. Valid options are [`Dataset`](@ref)

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -238,4 +238,3 @@ end
 function StatsBase.summarystats(data::InferenceObjects.Dataset; kwargs...)
     return summarize(data; kwargs...)
 end
-

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -222,9 +222,8 @@ function _summarize(
     kwargs...,
 )
     ds = _summarize(InferenceObjects.Dataset, data; metric_dim, kwargs...)
-    row_iter = _flat_iterator(ds, metric_dim; compact_labels)
-    nts = Tables.columntable(row_iter)
-    return SummaryStats(nts)
+    table = _as_flat_table(ds, metric_dim; compact_labels)
+    return SummaryStats(table)
 end
 
 function _interval_prob_to_strings(interval_type, prob; digits=2)

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -1,0 +1,241 @@
+"""
+    SummaryStats{D}
+
+A container for a column table of values computed by [`summarystatistics`](@ref).
+
+The first column is `variable`, and all remaining columns are the summary statistics.
+This object implements the Tables and TableTraits interfaces and has a custom `show` method.
+"""
+struct SummaryStats{D}
+    data::D
+end
+
+function Base.show(
+    io::IO, stats::SummaryStats; sigdigits_se=2, sigdigits_default=3, kwargs...
+)
+    colnames = keys(stats.data)
+    formatters = function (v, i, j)
+        colname = colnames[j]
+        if j == 1
+            return v
+        elseif Symbol("mcse_$colname") ∈ colnames
+            se = stats.data[Symbol("mcse_$colname")][i]
+            sigdigits = sigdigits_matching_error(v, se)
+            sprint(Printf.format, Printf.Format("%.$(sigdigits)g"), v)
+        elseif startswith(string(colname), "mcse")
+            sigdigits = sigdigits_se
+            return sprint(Printf.format, Printf.Format("%.$(sigdigits)g"), v)
+        elseif colname === :rhat
+            return sprint(Printf.format, Printf.Format("%.2f"), v)
+        elseif startswith(string(colname), "ess")
+            return sprint(Printf.format, Printf.Format("%d"), v)
+        else
+            return sprint(Printf.format, Printf.Format("%.$(sigdigits_default)g"), v)
+        end
+    end
+    kwargs_new = merge(
+        (
+            title="SummaryStatistics",
+            show_subheader=false,
+            hlines=:none,
+            vlines=:none,
+            formatters,
+            newline_at_end=false,
+            alignment=[:l, fill(:r, length(colnames) - 1)...],
+            header=["", colnames[2:end]...],
+            title_crayon=PrettyTables.Crayon(),
+        ),
+        kwargs,
+    )
+    PrettyTables.pretty_table(io, stats.data; kwargs_new...)
+    return nothing
+end
+
+#### Tables interface as column table
+
+Tables.istable(::Type{<:SummaryStats}) = true
+Tables.columnaccess(::Type{<:SummaryStats}) = true
+Tables.columns(s::SummaryStats) = s
+Tables.columnnames(s::SummaryStats) = Tables.columnnames(s.data)
+Tables.getcolumn(s::SummaryStats, i::Int) = Tables.getcolumn(s.data, i)
+Tables.getcolumn(s::SummaryStats, nm::Symbol) = Tables.getcolumn(s.data, nm)
+
+IteratorInterfaceExtensions.isiterable(::SummaryStats) = true
+function IteratorInterfaceExtensions.getiterator(s::SummaryStats)
+    return Tables.datavaluerows(Tables.columntable(s))
+end
+
+TableTraits.isiterabletable(::SummaryStats) = true
+
+"""
+    summarystats(data::InferenceData; group=:posterior, kwargs...)
+    summarystats(data::Dataset; kwargs...)
+
+Compute summary statistics and diagnostics on the `data`.
+
+# Keywords
+
+  - `return_type::Type`: The type of object to return. Valid options are [`Dataset`](@ref)
+  and [`SummaryStats`](@ref). Defaults to `SummaryStats`.
+  - `hdi_prob::Real`: The value of the `prob` argument to [`hdi`](@ref) used to compute the
+  highest density interval. Defaults to $(HDI_DEFAULT_PROB).
+  - `metric_dim`: The dimension name or type to use for the computed metrics. Only specify
+  if `return_type` is `Dataset`. Defaults to `Dim{_:metric}`.
+  - `compact_names::Bool`: Whether to use compact names for the variables. Only used if
+  `return_type` is `SummaryStats`. Defaults to `true`.
+  - `kind::Symbol`: Whether to compute just statistics (`:stats`), just diagnostics
+  (`:diagnostics`), or both (`:both`). Defaults to `:both`.
+
+# Examples
+
+Compute the summary statistics and diagnostics on posterior draws of the centered eight
+model:
+
+```jldoctest summarystats
+julia> idata = load_example_data("centered_eight");
+
+julia> summarystats(idata.posterior[(:mu, :tau)])
+SummaryStatistics
+      mean  std  hdi_3%  hdi_97%  mcse_mean  mcse_std  ess_tail  ess_bulk  rhat
+ mu    4.5  3.5   -1.62     10.7       0.23      0.11       659       241  1.02
+ tau   4.1  3.1   0.896     9.67       0.26      0.17        38        67  1.06
+```
+
+Compute just the statistics on all variables:
+
+```jldoctest summarystats
+julia> summarystats(idata.posterior; kind=:stats)
+SummaryStatistics
+                          mean   std  hdi_3%  hdi_97%
+ mu                       4.49  3.49   -1.62     10.7
+ theta[Choate]            6.46  5.87   -4.56     17.1
+ theta[Deerfield]         5.03  4.88   -4.31     14.3
+ theta[Phillips Andover]  3.94  5.69   -7.77     13.7
+ theta[Phillips Exeter]   4.87  5.01   -4.49     14.7
+ theta[Hotchkiss]         3.67  4.96   -6.47     11.7
+ theta[Lawrenceville]     3.97  5.19   -7.04     12.2
+ theta[St. Paul's]        6.58  5.11   -3.09     16.3
+ theta[Mt. Hermon]        4.77  5.74   -5.86       16
+ tau                      4.12   3.1   0.896     9.67
+```
+"""
+function summarystats(
+    data::InferenceObjects.InferenceData; group::Symbol=:posterior, kwargs...
+)
+    return summarystats(data[group]; kwargs...)
+end
+function summarystats(
+    data::InferenceObjects.Dataset; return_type::Type=SummaryStats, kwargs...
+)
+    return _summarize(return_type, data; kwargs...)
+end
+
+function _summarize(
+    ::Type{InferenceObjects.Dataset},
+    data::InferenceObjects.Dataset;
+    kind::Symbol=:both,
+    hdi_prob::Real=HDI_DEFAULT_PROB,
+    metric_dim=Dimensions.Dim{:metric},
+)
+    dims = InferenceObjects.DEFAULT_SAMPLE_DIMS
+    stats = [
+        "mean" => (data -> dropdims(Statistics.mean(data; dims); dims)),
+        "std" => (data -> dropdims(Statistics.std(data; dims); dims)),
+        _hdi_prob_to_strings(hdi_prob) => (data -> hdi(data; prob=hdi_prob)),
+    ]
+    diagnostics = [
+        "mcse_mean" => (data -> MCMCDiagnosticTools.mcse(data; kind=Statistics.mean)),
+        "mcse_std" => (data -> MCMCDiagnosticTools.mcse(data; kind=Statistics.std)),
+        "ess_tail" => (data -> MCMCDiagnosticTools.ess(data; kind=:tail)),
+        ("ess_bulk", "rhat") => (data -> MCMCDiagnosticTools.ess_rhat(data; kind=:bulk)),
+    ]
+    metrics = if kind === :both
+        vcat(stats, diagnostics)
+    elseif kind === :stats
+        stats
+    elseif kind === :diagnostics
+        diagnostics
+    else
+        error("Invalid value for `kind`: $kind")
+    end
+    metric_vals = map(metrics) do (_, f)
+        f(data)
+    end
+    metric_names = collect(Iterators.flatten(vcat(map(_astuple ∘ first, metrics))))
+    cat_dim = metric_dim(metric_names)
+    return cat(metric_vals...; dims=cat_dim)::InferenceObjects.Dataset
+end
+function _summarize(
+    ::Type{SummaryStats},
+    data::InferenceObjects.Dataset;
+    compact_names::Bool=true,
+    kwargs...,
+)
+    metric_dim = Dimensions.Dim{:_metric}
+    ds = _summarize(InferenceObjects.Dataset, data; metric_dim, kwargs...)
+    row_iter = _flat_iterator(ds, metric_dim; compact_names)
+    nts = Tables.columntable(row_iter)
+    return SummaryStats(nts)
+end
+
+function _hdi_prob_to_strings(prob; digits=2)
+    α = (1 - prob) / 2
+    perc_lower = string(round(100 * α; digits))
+    perc_upper = string(round(100 * (1 - α); digits))
+    return map((perc_lower, perc_upper)) do s
+        s = replace(s, r"\.0+$" => "")
+        return "hdi_$s%"
+    end
+end
+
+function _flat_iterator(ds, dim; compact_names=true)
+    var_iter = pairs(DimensionalData.layers(ds))
+    return Iterators.flatten(
+        Iterators.map(var_iter) do (var_name, var)
+            dims_flatten = Dimensions.otherdims(var, dim)
+            isempty(dims_flatten) &&
+                return ((variable="$var_name", _arr_to_namedtuple(var)...),)
+            indices_iter = DimensionalData.DimKeys(dims_flatten)
+            return Iterators.map(indices_iter) do indices
+                (
+                    variable=_indices_to_name(var_name, indices, compact_names),
+                    _arr_to_namedtuple(view(var, indices...))...,
+                )
+            end
+        end,
+    )
+end
+
+function _arr_to_namedtuple(arr::DimensionalData.AbstractDimVector)
+    ks = Tuple(map(Symbol, DimensionalData.lookup(arr, 1)))
+    return NamedTuple{ks}(Tuple(arr))
+end
+
+function _indices_to_name(name, dims, compact)
+    elements = if compact
+        map(string ∘ Dimensions.val ∘ Dimensions.val, dims)
+    else
+        map(dims) do d
+            val = Dimensions.val(Dimensions.val(d))
+            val_str = sprint(show, "text/plain", val)
+            return "$(Dimensions.name(d))=At($val_str)"
+        end
+    end
+    return "$name[" * join(elements, ',') * "]"
+end
+
+"""
+    summarystats(data::InferenceData; group=:posterior, kwargs...)
+    summarystats(data::Dataset; kwargs...)
+
+Compute summary statistics on `data`.
+
+These methods simply forward to [`summarize`](@ref). See that docstring for details.
+"""
+function StatsBase.summarystats(data::InferenceObjects.InferenceData; kwargs...)
+    return summarize(data; kwargs...)
+end
+function StatsBase.summarystats(data::InferenceObjects.Dataset; kwargs...)
+    return summarize(data; kwargs...)
+end
+

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -10,6 +10,19 @@ struct SummaryStats{D}
     data::D
 end
 
+# forward key interfaces from its parent
+Base.parent(stats::SummaryStats) = getfield(stats, :data)
+Base.propertynames(stats::SummaryStats) = propertynames(parent(stats))
+Base.getproperty(stats::SummaryStats, nm::Symbol) = getproperty(parent(stats), nm)
+Base.keys(stats::SummaryStats) = keys(parent(stats))
+Base.haskey(stats::SummaryStats, nm::Symbol) = haskey(parent(stats), nm)
+Base.length(stats::SummaryStats) = length(parent(stats))
+Base.getindex(stats::SummaryStats, i::Int) = getindex(parent(stats), i)
+Base.getindex(stats::SummaryStats, nm::Symbol) = getindex(parent(stats), nm)
+function Base.iterate(stats::SummaryStats, i::Int=firstindex(parent(stats)))
+    return iterate(parent(stats), i)
+end
+
 function Base.show(
     io::IO, stats::SummaryStats; sigdigits_se=2, sigdigits_default=3, kwargs...
 )

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -93,9 +93,9 @@ _is_ess_label(k::Symbol) = ((k === :ess) || startswith(string(k), "ess_"))
 Tables.istable(::Type{<:SummaryStats}) = true
 Tables.columnaccess(::Type{<:SummaryStats}) = true
 Tables.columns(s::SummaryStats) = s
-Tables.columnnames(s::SummaryStats) = Tables.columnnames(s.data)
-Tables.getcolumn(s::SummaryStats, i::Int) = Tables.getcolumn(s.data, i)
-Tables.getcolumn(s::SummaryStats, nm::Symbol) = Tables.getcolumn(s.data, nm)
+Tables.columnnames(s::SummaryStats) = Tables.columnnames(parent(s))
+Tables.getcolumn(s::SummaryStats, i::Int) = Tables.getcolumn(parent(s), i)
+Tables.getcolumn(s::SummaryStats, nm::Symbol) = Tables.getcolumn(parent(s), nm)
 
 IteratorInterfaceExtensions.isiterable(::SummaryStats) = true
 function IteratorInterfaceExtensions.getiterator(s::SummaryStats)

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -60,6 +60,9 @@ Tables.columns(s::SummaryStats) = s
 Tables.columnnames(s::SummaryStats) = Tables.columnnames(parent(s))
 Tables.getcolumn(s::SummaryStats, i::Int) = Tables.getcolumn(parent(s), i)
 Tables.getcolumn(s::SummaryStats, nm::Symbol) = Tables.getcolumn(parent(s), nm)
+Tables.rowaccess(::Type{<:SummaryStats}) = true
+Tables.rows(s::SummaryStats) = Tables.rows(parent(s))
+Tables.schema(s::SummaryStats) = Tables.schema(parent(s))
 
 IteratorInterfaceExtensions.isiterable(::SummaryStats) = true
 function IteratorInterfaceExtensions.getiterator(s::SummaryStats)

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -195,7 +195,7 @@ function _summarize(
         "mcse_mean" => (data -> MCMCDiagnosticTools.mcse(data; kind=Statistics.mean)),
         "mcse_std" => (data -> MCMCDiagnosticTools.mcse(data; kind=Statistics.std)),
         "ess_tail" => (data -> MCMCDiagnosticTools.ess(data; kind=:tail)),
-        ("ess_bulk", "rhat") => (data -> MCMCDiagnosticTools.ess_rhat(data; kind=:bulk)),
+        ("ess_bulk", "rhat") => (data -> MCMCDiagnosticTools.ess_rhat(data)),
     ]
     metrics = if kind === :both
         vcat(stats, diagnostics)

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -129,31 +129,34 @@ Compute the summary statistics and diagnostics on posterior draws of the centere
 model:
 
 ```jldoctest summarystats
+julia> using ArviZ, ArviZExampleData
+
 julia> idata = load_example_data("centered_eight");
 
 julia> summarystats(idata.posterior[(:mu, :tau)])
-SummaryStatistics
-      mean  std  hdi_3%  hdi_97%  mcse_mean  mcse_std  ess_tail  ess_bulk  rhat
- mu    4.5  3.5   -1.62     10.7       0.23      0.11       659       241  1.02
- tau   4.1  3.1   0.896     9.67       0.26      0.17        38        67  1.06
+SummaryStats
+      mean  std  hdi_3%  hdi_97%  mcse_mean  mcse_std  ess_tail  ess_bulk  rha ⋯
+ mu    4.5  3.5  -1.62     10.7        0.23      0.11       659       241  1.0 ⋯
+ tau   4.1  3.1   0.896     9.67       0.26      0.17        38        67  1.0 ⋯
+                                                                1 column omitted
 ```
 
 Compute just the statistics on all variables:
 
 ```jldoctest summarystats
 julia> summarystats(idata.posterior; kind=:stats)
-SummaryStatistics
+SummaryStats
                           mean   std  hdi_3%  hdi_97%
- mu                       4.49  3.49   -1.62     10.7
- theta[Choate]            6.46  5.87   -4.56     17.1
- theta[Deerfield]         5.03  4.88   -4.31     14.3
- theta[Phillips Andover]  3.94  5.69   -7.77     13.7
- theta[Phillips Exeter]   4.87  5.01   -4.49     14.7
- theta[Hotchkiss]         3.67  4.96   -6.47     11.7
- theta[Lawrenceville]     3.97  5.19   -7.04     12.2
- theta[St. Paul's]        6.58  5.11   -3.09     16.3
- theta[Mt. Hermon]        4.77  5.74   -5.86       16
- tau                      4.12   3.1   0.896     9.67
+ mu                       4.49  3.49  -1.62     10.7
+ theta[Choate]            6.46  5.87  -4.56     17.1
+ theta[Deerfield]         5.03  4.88  -4.31     14.3
+ theta[Phillips Andover]  3.94  5.69  -7.77     13.7
+ theta[Phillips Exeter]   4.87  5.01  -4.49     14.7
+ theta[Hotchkiss]         3.67  4.96  -6.47     11.7
+ theta[Lawrenceville]     3.97  5.19  -7.04     12.2
+ theta[St. Paul's]        6.58  5.11  -3.09     16.3
+ theta[Mt. Hermon]        4.77  5.74  -5.86     16.0
+ tau                      4.12  3.10   0.896     9.67
 ```
 """
 function StatsBase.summarystats(

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -163,6 +163,20 @@ SummaryStats
  theta[Mt. Hermon]        4.77  5.74  -5.86     16.0
  tau                      4.12  3.10   0.896     9.67
 ```
+
+Compute the statistics and diagnostics from the posterior group of an `InferenceData` and
+store in a `Dataset`:
+
+```jldoctest summarystats
+julia> summarystats(idata; return_type=Dataset)
+Dataset with dimensions:
+  Dim{:_metric} Categorical{String} String[mean, std, …, ess_bulk, rhat] Unordered,
+  Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
+and 3 layers:
+  :mu    Float64 dims: Dim{:_metric} (9)
+  :theta Float64 dims: Dim{:school}, Dim{:_metric} (8×9)
+  :tau   Float64 dims: Dim{:_metric} (9)
+```
 """
 function StatsBase.summarystats(
     data::InferenceObjects.InferenceData; group::Symbol=:posterior, kwargs...

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -1,7 +1,7 @@
 """
     SummaryStats{D}
 
-A container for a column table of values computed by [`summarystatistics`](@ref).
+A container for a column table of values computed by [`summarystats`](@ref).
 
 The first column is `variable`, and all remaining columns are the summary statistics.
 This object implements the Tables and TableTraits interfaces and has a custom `show` method.

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -118,7 +118,7 @@ Compute summary statistics and diagnostics on the `data`.
   highest density interval. Defaults to $(DEFAULT_INTERVAL_PROB).
   - `metric_dim`: The dimension name or type to use for the computed metrics. Only specify
   if `return_type` is `Dataset`. Defaults to `Dim{_:metric}`.
-  - `compact_names::Bool`: Whether to use compact names for the variables. Only used if
+  - `compact_labels::Bool`: Whether to use compact names for the variables. Only used if
   `return_type` is `SummaryStats`. Defaults to `true`.
   - `kind::Symbol`: Whether to compute just statistics (`:stats`), just diagnostics
   (`:diagnostics`), or both (`:both`). Defaults to `:both`.
@@ -206,12 +206,12 @@ end
 function _summarize(
     ::Type{SummaryStats},
     data::InferenceObjects.Dataset;
-    compact_names::Bool=true,
+    compact_labels::Bool=true,
     kwargs...,
 )
     metric_dim = Dimensions.Dim{:_metric}
     ds = _summarize(InferenceObjects.Dataset, data; metric_dim, kwargs...)
-    row_iter = _flat_iterator(ds, metric_dim; compact_names)
+    row_iter = _flat_iterator(ds, metric_dim; compact_labels)
     nts = Tables.columntable(row_iter)
     return SummaryStats(nts)
 end
@@ -226,7 +226,7 @@ function _interval_prob_to_strings(interval_type, prob; digits=2)
     end
 end
 
-function _flat_iterator(ds, dim; compact_names=true)
+function _flat_iterator(ds, dim; compact_labels=true)
     var_iter = pairs(DimensionalData.layers(ds))
     return Iterators.flatten(
         Iterators.map(var_iter) do (var_name, var)
@@ -236,7 +236,7 @@ function _flat_iterator(ds, dim; compact_names=true)
             indices_iter = DimensionalData.DimKeys(dims_flatten)
             return Iterators.map(indices_iter) do indices
                 (
-                    variable=_indices_to_name(var_name, indices, compact_names),
+                    variable=_indices_to_name(var_name, indices, compact_labels),
                     _arr_to_namedtuple(view(var, indices...))...,
                 )
             end

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -184,7 +184,7 @@ function _summarize(
     prob_interval::Real=DEFAULT_INTERVAL_PROB,
     metric_dim=DEFAULT_METRIC_DIM,
 )
-    dims = InferenceObjects.DEFAULT_SAMPLE_DIMS
+    dims = Dimensions.dims(data, InferenceObjects.DEFAULT_SAMPLE_DIMS)
     stats = [
         "mean" => (data -> dropdims(Statistics.mean(data; dims); dims)),
         "std" => (data -> dropdims(Statistics.std(data; dims); dims)),

--- a/src/ArviZStats/summarystats.jl
+++ b/src/ArviZStats/summarystats.jl
@@ -33,6 +33,9 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", stats::SummaryStats; kwargs...)
     return _show(io, mime, stats; kwargs...)
 end
+function Base.show(io::IO, mime::MIME"text/html", stats::SummaryStats; kwargs...)
+    return _show(io, mime, stats; kwargs...)
+end
 
 function _show(io::IO, mime::MIME, stats::SummaryStats; kwargs...)
     data = parent(stats)[eachindex(stats)[2:end]]

--- a/src/ArviZStats/utils.jl
+++ b/src/ArviZStats/utils.jl
@@ -518,5 +518,12 @@ function _show_prettytable(
         kwargs...,
     )
 end
+function _show_prettytable(
+    io::IO, ::MIME"text/html", data; minify=true, max_num_of_rows=25, kwargs...
+)
+    return _show_prettytable(
+        io, data; backend=Val(:html), minify, max_num_of_rows, kwargs...
+    )
+end
 
 _is_ess_label(k::Symbol) = ((k === :ess) || startswith(string(k), "ess_"))

--- a/src/ArviZStats/utils.jl
+++ b/src/ArviZStats/utils.jl
@@ -363,42 +363,22 @@ end
 
 Use Printf to format the elements in the `columns` to the number of `sigdigits`.
 
-If `sigdigits` is a vector, then columns must be also be a vector with the same number of
-elements.
 If `sigdigits` is a `Real`, and `columns` is not specified (or is empty), then the
 formatting will be applied to the entire table.
 Otherwise, if `sigdigits` is a `Real` and `columns` is a vector, then the elements in the
 columns will be formatted to the number of `sigdigits`.
 """
-ft_printf_sigdigits(sigdigits::Int) = ft_printf_sigdigits([sigdigits])
-function ft_printf_sigdigits(sigdigits::Int, columns::AbstractVector{Int})
-    return ft_printf_sigdigits([sigdigits for _ in eachindex(columns)], columns)
-end
-function ft_printf_sigdigits(
-    sigdigits::AbstractVector{Int}, columns::AbstractVector{Int}=Int[]
-)
-    lc = length(columns)
-
-    if lc == 0 && (length(sigdigits) != 1)
-        error("If columns is empty, then sigdigits must have only one element.")
-    end
-
-    if lc > 0 && (length(sigdigits) != lc)
-        error(
-            "The vector columns must have the same number of elements of the vector sigdigits.",
-        )
-    end
-
-    if lc == 0
+function ft_printf_sigdigits(sigdigits::Int, columns::AbstractVector{Int}=Int[])
+    if isempty(columns)
         return (v, _, _) -> begin
             v isa Real || return v
-            return _printf_with_sigdigits(v, first(sigdigits))
+            return _printf_with_sigdigits(v, sigdigits)
         end
     else
         return (v, _, j) -> begin
             v isa Real || return v
-            for (col, sigdigit) in zip(columns, sigdigits)
-                col == j && return _printf_with_sigdigits(v, sigdigit)
+            for col in columns
+                col == j && return _printf_with_sigdigits(v, sigdigits)
             end
             return v
         end

--- a/src/ArviZStats/utils.jl
+++ b/src/ArviZStats/utils.jl
@@ -207,24 +207,6 @@ function _smooth_data!(y_interp, interp_method, y, x, x_interp, dims)
     return y_interp
 end
 
-"""
-    sigdigits_matching_error(x, se; sigdigits_max=7, scale=2) -> Int
-
-Get number of significant digits of `x` so that the last digit of `x` is the first digit of
-`se*scale`.
-"""
-function sigdigits_matching_error(x::Real, se::Real; sigdigits_max::Int=7, scale::Real=2)
-    (iszero(x) || !isfinite(x) || !isfinite(se) || !isfinite(scale)) && return 0
-    sigdigits_max ≥ 0 || throw(ArgumentError("`sigdigits_max` must be non-negative"))
-    se ≥ 0 || throw(ArgumentError("`se` must be non-negative"))
-    iszero(se) && return sigdigits_max
-    scale > 0 || throw(ArgumentError("`scale` must be positive"))
-    first_digit_x = floor(Int, log10(abs(x)))
-    last_digit_x = floor(Int, log10(se * scale))
-    sigdigits_x = first_digit_x - last_digit_x + 1
-    return clamp(sigdigits_x, 0, sigdigits_max)
-end
-
 Base.@pure _typename(::T) where {T} = T.name.name
 
 _astuple(x) = (x,)
@@ -343,4 +325,22 @@ function _se_log_mean(
     # use delta method to asymptotically map variance of mean to variance of logarithm of mean
     se_log_mean = @. exp(log_var_mean / 2 - log_mean)
     return se_log_mean
+end
+
+"""
+    sigdigits_matching_se(x, se; sigdigits_max=7, scale=2) -> Int
+
+Get number of significant digits of `x` so that the last digit of `x` is the first digit of
+`se*scale`.
+"""
+function sigdigits_matching_se(x::Real, se::Real; sigdigits_max::Int=7, scale::Real=2)
+    (iszero(x) || !isfinite(x) || !isfinite(se) || !isfinite(scale)) && return 0
+    sigdigits_max ≥ 0 || throw(ArgumentError("`sigdigits_max` must be non-negative"))
+    se ≥ 0 || throw(ArgumentError("`se` must be non-negative"))
+    iszero(se) && return sigdigits_max
+    scale > 0 || throw(ArgumentError("`scale` must be positive"))
+    first_digit_x = floor(Int, log10(abs(x)))
+    last_digit_x = floor(Int, log10(se * scale))
+    sigdigits_x = first_digit_x - last_digit_x + 1
+    return clamp(sigdigits_x, 0, sigdigits_max)
 end

--- a/src/ArviZStats/waic.jl
+++ b/src/ArviZStats/waic.jl
@@ -18,9 +18,8 @@ function elpd_estimates(r::WAICResult; pointwise::Bool=false)
     return pointwise ? r.pointwise : r.estimates
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", result::WAICResult)
-    println(io, "WAICResult with estimates")
-    _print_elpd_estimates(io, mime, result)
+function Base.show(io::IO, mime::MIME"text/plain", result::WAICResult; kwargs...)
+    _show_elpd_estimates(io, mime, result; title="WAICResult with estimates", kwargs...)
     return nothing
 end
 

--- a/src/ArviZStats/waic.jl
+++ b/src/ArviZStats/waic.jl
@@ -55,9 +55,8 @@ julia> log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :s
 
 julia> waic(log_like)
 WAICResult with estimates
-       Estimate    SE
- elpd       -31   1.4
-    p       0.9  0.33
+ elpd  elpd_mcse    p  p_mcse
+  -31        1.4  0.9    0.33
 ```
 """
 waic(ll::AbstractArray) = _waic(ll)
@@ -81,9 +80,8 @@ julia> idata = load_example_data("centered_eight");
 
 julia> waic(idata)
 WAICResult with estimates
-       Estimate    SE
- elpd       -31   1.4
-    p       0.9  0.33
+ elpd  elpd_mcse    p  p_mcse
+  -31        1.4  0.9    0.33
 ```
 """
 function waic(

--- a/test/ArviZStats/compare.jl
+++ b/test/ArviZStats/compare.jl
@@ -1,5 +1,6 @@
 using Test
 using ArviZ
+using ArviZExampleData
 using DimensionalData
 using IteratorInterfaceExtensions
 using Tables
@@ -111,13 +112,13 @@ end
             mc5 = compare(eight_schools_loo_results; weights_method=PseudoBMA())
             @test sprint(show, "text/plain", mc1) == """
                 ModelComparisonResult with Stacking weights
-                 name          rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
+                               rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
                  non_centered     1   -31        1.4       0              0.0       1.0  0.9    0.32
                  centered         2   -31        1.4       0.06           0.067     0.0  0.9    0.34"""
 
             @test sprint(show, "text/plain", mc5) == """
                 ModelComparisonResult with PseudoBMA weights
-                 name          rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
+                               rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
                  non_centered     1   -31        1.4       0              0.0      0.52  0.9    0.32
                  centered         2   -31        1.4       0.06           0.067    0.48  0.9    0.34"""
         end

--- a/test/ArviZStats/compare.jl
+++ b/test/ArviZStats/compare.jl
@@ -108,11 +108,18 @@ end
         end
 
         @testset "show" begin
+            mc5 = compare(eight_schools_loo_results; weights_method=PseudoBMA())
             @test sprint(show, "text/plain", mc1) == """
                 ModelComparisonResult with Stacking weights
-                         name  rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
-                 non_centered     1   -31        1.4          0               0     1.0  0.9    0.32
-                     centered     2   -31        1.4       0.06           0.067     0.0  0.9    0.34"""
+                 name          rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
+                 non_centered     1   -31        1.4       0              0.0       1.0  0.9    0.32
+                 centered         2   -31        1.4       0.06           0.067     0.0  0.9    0.34"""
+
+            @test sprint(show, "text/plain", mc5) == """
+                ModelComparisonResult with PseudoBMA weights
+                 name          rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
+                 non_centered     1   -31        1.4       0              0.0      0.52  0.9    0.32
+                 centered         2   -31        1.4       0.06           0.067    0.48  0.9    0.34"""
         end
     end
 end

--- a/test/ArviZStats/compare.jl
+++ b/test/ArviZStats/compare.jl
@@ -121,6 +121,8 @@ end
                                rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
                  non_centered     1   -31        1.4       0              0.0      0.52  0.9    0.32
                  centered         2   -31        1.4       0.06           0.067    0.48  0.9    0.34"""
+
+            @test startswith(sprint(show, "text/html", mc1), "<table")
         end
     end
 end

--- a/test/ArviZStats/compare.jl
+++ b/test/ArviZStats/compare.jl
@@ -91,6 +91,9 @@ end
                 @test Tables.getcolumn(mc1, i) == Tables.getcolumn(mc1, k)
             end
             @test_throws ArgumentError Tables.getcolumn(mc1, :foo)
+            @test Tables.rowaccess(typeof(mc1))
+            @test map(NamedTuple, Tables.rows(mc1)) ==
+                map(NamedTuple, Tables.rows(Tables.columntable(mc1)))
         end
 
         @testset "TableTraits interface" begin

--- a/test/ArviZStats/loo.jl
+++ b/test/ArviZStats/loo.jl
@@ -151,9 +151,8 @@ include("helpers.jl")
         # regression test
         @test sprint(show, "text/plain", loo(idata)) == """
             PSISLOOResult with estimates
-                   Estimate    SE
-             elpd       -31   1.4
-                p       0.9  0.34
+             elpd  elpd_mcse    p  p_mcse
+              -31        1.4  0.9    0.34
 
             and PSISResult with 500 draws, 4 chains, and 8 parameters
             Pareto shape (k) diagnostic values:

--- a/test/ArviZStats/model_weights.jl
+++ b/test/ArviZStats/model_weights.jl
@@ -111,7 +111,7 @@ struct DummyOptimizer <: Optim.AbstractOptimizer end
             obj(nothing, grad, x)
             @test grad ≈ grad_exp
 
-            @test @allocated(obj(true, nothing, x)) ≤ 16
+            @test @allocated(obj(true, nothing, x)) ≤ 32
             @test @allocated(obj(true, grad, x)) == @allocated(obj(true, nothing, x))
         end
 

--- a/test/ArviZStats/runtests.jl
+++ b/test/ArviZStats/runtests.jl
@@ -15,4 +15,5 @@ Random.seed!(97)
     include("model_weights.jl")
     include("compare.jl")
     include("r2_score.jl")
+    include("summarystats.jl")
 end

--- a/test/ArviZStats/summarystats.jl
+++ b/test/ArviZStats/summarystats.jl
@@ -1,7 +1,10 @@
 using ArviZ
 using ArviZExampleData
 using DimensionalData
-using StatsBase
+using IteratorInterfaceExtensions
+using Statistics
+using Tables
+using TableTraits
 using Test
 
 _maybescalar(x) = x
@@ -207,6 +210,96 @@ _maybevec(x) = x
                 keys(parent(stats2)),
                 [:variable, :mean, :std, Symbol("hdi_10%"), Symbol("hdi_90%")],
             )
+        end
+    end
+
+    @testset "SummaryStats" begin
+        data = (
+            variable=["a", "bb", "ccc", "d", "e"],
+            est=randn(5),
+            mcse_est=randn(5),
+            rhat=rand(5),
+            ess=rand(5),
+        )
+
+        stats = @inferred SummaryStats(data)
+
+        @testset "basic interfaces" begin
+            @test parent(stats) === data
+            @test propertynames(stats) == propertynames(data)
+            for k in propertynames(stats)
+                @test getproperty(stats, k) == getproperty(data, k)
+            end
+            @test keys(stats) == keys(data)
+            for k in keys(stats)
+                @test haskey(stats, k) == haskey(data, k)
+                @test getindex(stats, k) == getindex(data, k)
+            end
+            @test !haskey(stats, :foo)
+            @test length(stats) == length(data)
+            for i in eachindex(stats)
+                @test getindex(stats, i) == getindex(data, i)
+            end
+            @test Base.iterate(stats) == Base.iterate(data)
+            @test Base.iterate(stats, 2) == Base.iterate(data, 2)
+        end
+
+        @testset "Tables interface" begin
+            @test Tables.istable(typeof(stats))
+            @test Tables.columnaccess(typeof(stats))
+            @test Tables.columns(stats) === stats
+            @test Tables.columnnames(stats) == keys(stats)
+            table = Tables.columntable(stats)
+            @test table == data
+            for (i, k) in enumerate(Tables.columnnames(stats))
+                @test Tables.getcolumn(stats, i) == Tables.getcolumn(stats, k)
+            end
+            @test_throws ErrorException Tables.getcolumn(stats, :foo)
+        end
+
+        @testset "TableTraits interface" begin
+            @test IteratorInterfaceExtensions.isiterable(stats)
+            @test TableTraits.isiterabletable(stats)
+            nt = collect(Iterators.take(IteratorInterfaceExtensions.getiterator(stats), 1))[1]
+            @test isequal(
+                nt,
+                (;
+                    (
+                        k => Tables.getcolumn(stats, k)[1] for
+                        k in Tables.columnnames(stats)
+                    )...
+                ),
+            )
+            nt = collect(Iterators.take(IteratorInterfaceExtensions.getiterator(stats), 2))[2]
+            @test isequal(
+                nt,
+                (;
+                    (
+                        k => Tables.getcolumn(stats, k)[2] for
+                        k in Tables.columnnames(stats)
+                    )...
+                ),
+            )
+        end
+
+        @testset "show" begin
+            data = (
+                variable=["a", "bb", "ccc", "d", "e"],
+                est=[111.11, 1.2345e-6, 5.4321e8, Inf, NaN],
+                mcse_est=[0.0012345, 5.432e-5, 2.1234e5, Inf, NaN],
+                rhat=vcat(1.009, 1.011, 0.99, Inf, NaN),
+                ess=vcat(312.45, 23.32, 1011.98, Inf, NaN),
+                ess_bulk=vcat(9.2345, 876.321, 999.99, Inf, NaN),
+            )
+            stats = SummaryStats(data)
+            @test sprint(show, "text/plain", stats) == """
+                SummaryStats
+                              est  mcse_est  rhat   ess  ess_bulk
+                 a    111.110       0.0012   1.01   312         9
+                 bb     1.e-06      5.4e-05  1.01    23       876
+                 ccc    5.432e+08   2.1e+05  0.99  1012      1000
+                 d       Inf         Inf      Inf   Inf       Inf
+                 e       NaN         NaN      NaN   NaN       NaN"""
         end
     end
 end

--- a/test/ArviZStats/summarystats.jl
+++ b/test/ArviZStats/summarystats.jl
@@ -261,6 +261,9 @@ _maybevec(x) = x
                 @test Tables.getcolumn(stats, i) == Tables.getcolumn(stats, k)
             end
             @test_throws ErrorException Tables.getcolumn(stats, :foo)
+            @test Tables.rowaccess(typeof(stats))
+            @test Tables.rows(stats) == Tables.rows(parent(stats))
+            @test Tables.schema(stats) == Tables.schema(parent(stats))
         end
 
         @testset "TableTraits interface" begin

--- a/test/ArviZStats/summarystats.jl
+++ b/test/ArviZStats/summarystats.jl
@@ -22,8 +22,14 @@ _maybevec(x) = x
                 dims=(y=[:a], z=[:b, :c]),
                 coords=(a=["q", "r", "s"], b=[0, 1], c=[:m, :n, :o]),
             )
+            idata1 = InferenceData(; posterior=ds)
+            idata2 = InferenceData(; prior=ds)
 
             stats = @inferred Dataset summarystats(ds; return_type=Dataset)
+            @test parent(stats) == parent(summarystats(idata1; return_type=Dataset))
+            @test parent(stats) ==
+                parent(summarystats(idata2; group=:prior, return_type=Dataset))
+
             @test issetequal(keys(stats), keys(ds))
             @test isempty(DimensionalData.metadata(stats))
             @test hasdim(stats, :_metric)
@@ -237,7 +243,7 @@ _maybevec(x) = x
             end
             @test !haskey(stats, :foo)
             @test length(stats) == length(data)
-            for i in eachindex(stats)
+            for i in 1:length(data)
                 @test getindex(stats, i) == getindex(data, i)
             end
             @test Base.iterate(stats) == Base.iterate(data)

--- a/test/ArviZStats/summarystats.jl
+++ b/test/ArviZStats/summarystats.jl
@@ -1,0 +1,212 @@
+using ArviZ
+using ArviZExampleData
+using DimensionalData
+using StatsBase
+using Test
+
+_maybescalar(x) = x
+_maybescalar(x::AbstractArray{<:Any,0}) = x[]
+
+_maybevec(x::AbstractArray) = vec(x)
+_maybevec(x) = x
+
+@testset "summary statistics" begin
+    @testset "summarystats" begin
+        @testset "return_type=Dataset" begin
+            data = (x=randn(100, 2), y=randn(100, 2, 3), z=randn(100, 2, 2, 3))
+            ds = convert_to_dataset(
+                data;
+                dims=(y=[:a], z=[:b, :c]),
+                coords=(a=["q", "r", "s"], b=[0, 1], c=[:m, :n, :o]),
+            )
+
+            stats = @inferred Dataset summarystats(ds; return_type=Dataset)
+            @test issetequal(keys(stats), keys(ds))
+            @test isempty(DimensionalData.metadata(stats))
+            @test hasdim(stats, :_metric)
+            @test lookup(stats, :_metric) == [
+                "mean",
+                "std",
+                "hdi_3%",
+                "hdi_97%",
+                "mcse_mean",
+                "mcse_std",
+                "ess_tail",
+                "ess_bulk",
+                "rhat",
+            ]
+            @test view(stats; _metric=At("mean")) ==
+                dropdims(mean(ds; dims=(:draw, :chain)); dims=(:draw, :chain))
+            @test view(stats; _metric=At("std")) ==
+                dropdims(std(ds; dims=(:draw, :chain)); dims=(:draw, :chain))
+            hdi_ds = hdi(ds)
+            @test stats[_metric=At("hdi_3%")] == hdi_ds[hdi_bound=1]
+            @test stats[_metric=At("hdi_97%")] == hdi_ds[hdi_bound=2]
+            @test view(stats; _metric=At("mcse_mean")) == mcse(ds; kind=mean)
+            @test view(stats; _metric=At("mcse_std")) == mcse(ds; kind=std)
+            @test view(stats; _metric=At("ess_tail")) == ess(ds; kind=:tail)
+            @test view(stats; _metric=At("ess_bulk")) == ess(ds; kind=:bulk)
+            @test view(stats; _metric=At("rhat")) == rhat(ds)
+
+            stats2 = summarystats(ds; return_type=Dataset, prob_interval=0.8)
+            @test lookup(stats2, :_metric) == [
+                "mean",
+                "std",
+                "hdi_10%",
+                "hdi_90%",
+                "mcse_mean",
+                "mcse_std",
+                "ess_tail",
+                "ess_bulk",
+                "rhat",
+            ]
+            hdi_ds2 = hdi(ds; prob=0.8)
+            @test stats2[_metric=At("hdi_10%")] == hdi_ds2[hdi_bound=1]
+            @test stats2[_metric=At("hdi_90%")] == hdi_ds2[hdi_bound=2]
+
+            stats3 = summarystats(ds; return_type=Dataset, kind=:stats)
+            @test lookup(stats3, :_metric) == ["mean", "std", "hdi_3%", "hdi_97%"]
+            @test stats3 == stats[_metric=At(["mean", "std", "hdi_3%", "hdi_97%"])]
+
+            stats4 = summarystats(ds; return_type=Dataset, kind=:diagnostics)
+            @test lookup(stats4, :_metric) ==
+                ["mcse_mean", "mcse_std", "ess_tail", "ess_bulk", "rhat"]
+            @test stats4 == stats[_metric=At([
+                "mcse_mean", "mcse_std", "ess_tail", "ess_bulk", "rhat"
+            ])]
+
+            stats5 = summarystats(
+                ds;
+                return_type=Dataset,
+                metric_dim=:__metric,
+                kind=:stats,
+                prob_interval=0.95,
+            )
+            @test lookup(stats5, :__metric) == ["mean", "std", "hdi_2.5%", "hdi_97.5%"]
+        end
+
+        @testset "_indices_iterator" begin
+            data = (x=randn(3), y=randn(3, 3), z=randn(3, 2, 3))
+            ds = namedtuple_to_dataset(
+                data;
+                dims=(x=[:s], y=[:s, :a], z=[:s, :b, :c]),
+                coords=(a=["q", "r", "s"], b=[0, 1], c=[:m, :n, :o]),
+                default_dims=(),
+            )
+            var_inds = collect(ArviZStats._indices_iterator(ds, :s))
+            @test length(var_inds) == 1 + size(ds.y, :a) + size(ds.z, :b) * size(ds.z, :c)
+            @test var_inds[1] == (data.x, ())
+            @test first.(var_inds[2:4]) == fill(data.y, size(ds.y, :a))
+            @test last.(var_inds[2:4]) == vec(DimensionalData.DimKeys(otherdims(ds.y, :s)))
+            @test first.(var_inds[5:end]) == fill(data.z, size(ds.z, :b) * size(ds.z, :c))
+            @test last.(var_inds[5:end]) ==
+                vec(DimensionalData.DimKeys(otherdims(ds.z, :s)))
+        end
+
+        @testset "_indices_to_name" begin
+            data = (x=randn(3), y=randn(3, 3), z=randn(3, 2, 3))
+            ds = namedtuple_to_dataset(
+                data;
+                dims=(x=[:s], y=[:s, :a], z=[:s, :b, :c]),
+                coords=(a=["q", "r", "s"], b=[0, 1], c=[:m, :n, :o]),
+                default_dims=(),
+            )
+
+            @test ArviZStats._indices_to_name(ds.x, (), true) == "x"
+            @test ArviZStats._indices_to_name(ds.x, (), false) == "x"
+            y_names = map(DimensionalData.DimKeys(dims(ds.y, :a))) do d
+                return ArviZStats._indices_to_name(ds.y, d, true)
+            end
+            @test y_names == ["y[q]", "y[r]", "y[s]"]
+            y_names_verbose = map(DimensionalData.DimKeys(dims(ds.y, :a))) do d
+                return ArviZStats._indices_to_name(ds.y, d, false)
+            end
+            @test y_names_verbose == ["y[a=At(\"q\")]", "y[a=At(\"r\")]", "y[a=At(\"s\")]"]
+            z_names = vec(
+                map(DimensionalData.DimKeys(dims(ds.z, (:b, :c)))) do d
+                    return ArviZStats._indices_to_name(ds.z, d, true)
+                end,
+            )
+            @test z_names == ["z[0,m]", "z[1,m]", "z[0,n]", "z[1,n]", "z[0,o]", "z[1,o]"]
+            z_names_verbose = vec(
+                map(DimensionalData.DimKeys(dims(ds.z, (:b, :c)))) do d
+                    return ArviZStats._indices_to_name(ds.z, d, false)
+                end,
+            )
+            @test z_names_verbose == [
+                "z[b=At(0),c=At(:m)]",
+                "z[b=At(1),c=At(:m)]",
+                "z[b=At(0),c=At(:n)]",
+                "z[b=At(1),c=At(:n)]",
+                "z[b=At(0),c=At(:o)]",
+                "z[b=At(1),c=At(:o)]",
+            ]
+        end
+
+        @testset "return_type=SummaryStats" begin
+            data = (x=randn(100, 2), y=randn(100, 2, 3), z=randn(100, 2, 2, 3))
+            ds = convert_to_dataset(
+                data;
+                dims=(y=[:a], z=[:b, :c]),
+                coords=(a=["q", "r", "s"], b=[0, 1], c=[:m, :n, :o]),
+            )
+
+            stats = @inferred SummaryStats summarystats(ds)
+            stats_data = parent(stats)
+            @test stats_data.variable == [
+                "x",
+                "y[q]",
+                "y[r]",
+                "y[s]",
+                "z[0,m]",
+                "z[1,m]",
+                "z[0,n]",
+                "z[1,n]",
+                "z[0,o]",
+                "z[1,o]",
+            ]
+            @test issetequal(
+                keys(stats_data),
+                [
+                    :variable,
+                    :mean,
+                    :std,
+                    Symbol("hdi_3%"),
+                    Symbol("hdi_97%"),
+                    :mcse_mean,
+                    :mcse_std,
+                    :ess_tail,
+                    :ess_bulk,
+                    :rhat,
+                ],
+            )
+
+            # check a handful of values
+            @test stats_data.mean == reduce(
+                vcat, map(vec, DimensionalData.layers(mean(ds; dims=(:draw, :chain))))
+            )
+            @test stats_data.std == reduce(
+                vcat, map(vec, DimensionalData.layers(std(ds; dims=(:draw, :chain))))
+            )
+            hdi_ds = hdi(ds)
+            @test stats_data[Symbol("hdi_3%")] ==
+                reduce(vcat, map(_maybevec, DimensionalData.layers(hdi_ds[hdi_bound=1])))
+            @test stats_data[Symbol("hdi_97%")] ==
+                reduce(vcat, map(_maybevec, DimensionalData.layers(hdi_ds[hdi_bound=2])))
+            @test stats_data.mcse_mean ==
+                reduce(vcat, map(_maybevec, DimensionalData.layers(mcse(ds; kind=mean))))
+            @test stats_data.mcse_std ==
+                reduce(vcat, map(_maybevec, DimensionalData.layers(mcse(ds; kind=std))))
+            @test stats_data.ess_bulk ==
+                reduce(vcat, map(_maybevec, DimensionalData.layers(ess(ds))))
+            @test stats_data.rhat ==
+                reduce(vcat, map(_maybevec, DimensionalData.layers(rhat(ds))))
+
+            stats2 = summarystats(ds; prob_interval=0.8, kind=:stats)
+            @test issetequal(
+                keys(parent(stats2)),
+                [:variable, :mean, :std, Symbol("hdi_10%"), Symbol("hdi_90%")],
+            )
+        end
+    end
+end

--- a/test/ArviZStats/summarystats.jl
+++ b/test/ArviZStats/summarystats.jl
@@ -306,6 +306,8 @@ _maybevec(x) = x
                  ccc    5.432e+08   2.1e+05  0.99  1012      1000
                  d       Inf         Inf      Inf   Inf       Inf
                  e       NaN         NaN      NaN   NaN       NaN"""
+
+            @test startswith(sprint(show, "text/html", stats), "<table")
         end
     end
 end

--- a/test/ArviZStats/utils.jl
+++ b/test/ArviZStats/utils.jl
@@ -330,4 +330,83 @@ using StatsBase
         @test ArviZStats.sigdigits_matching_se(100, 0) == 7
         @test ArviZStats.sigdigits_matching_se(100, 0; sigdigits_max=2) == 2
     end
+
+    @testset "_printf_with_sigdigits" begin
+        @test ArviZStats._printf_with_sigdigits(123.456, 1) == "1.e+02"
+        @test ArviZStats._printf_with_sigdigits(-123.456, 1) == "-1.e+02"
+        @test ArviZStats._printf_with_sigdigits(123.456, 2) == "1.2e+02"
+        @test ArviZStats._printf_with_sigdigits(-123.456, 2) == "-1.2e+02"
+        @test ArviZStats._printf_with_sigdigits(123.456, 3) == "123"
+        @test ArviZStats._printf_with_sigdigits(-123.456, 3) == "-123"
+        @test ArviZStats._printf_with_sigdigits(123.456, 4) == "123.5"
+        @test ArviZStats._printf_with_sigdigits(-123.456, 4) == "-123.5"
+        @test ArviZStats._printf_with_sigdigits(123.456, 5) == "123.46"
+        @test ArviZStats._printf_with_sigdigits(-123.456, 5) == "-123.46"
+        @test ArviZStats._printf_with_sigdigits(123.456, 6) == "123.456"
+        @test ArviZStats._printf_with_sigdigits(-123.456, 6) == "-123.456"
+        @test ArviZStats._printf_with_sigdigits(123.456, 7) == "123.4560"
+        @test ArviZStats._printf_with_sigdigits(-123.456, 7) == "-123.4560"
+        @test ArviZStats._printf_with_sigdigits(123.456, 8) == "123.45600"
+        @test ArviZStats._printf_with_sigdigits(0.00000123456, 1) == "1.e-06"
+        @test ArviZStats._printf_with_sigdigits(0.00000123456, 2) == "1.2e-06"
+    end
+
+    @testset "ft_printf_sigdigits" begin
+        @testset "all columns" begin
+            @testset for sigdigits in 1:5
+                ft1 = ArviZStats.ft_printf_sigdigits(sigdigits)
+                for i in 1:10, j in 1:5
+                    v = randn()
+                    @test ft1(v, i, j) == ArviZStats._printf_with_sigdigits(v, sigdigits)
+                    @test ft1("foo", i, j) == "foo"
+                end
+            end
+        end
+        @testset "subset of columns" begin
+            @testset for sigdigits in 1:5
+                ft = ArviZStats.ft_printf_sigdigits(sigdigits, [2, 3])
+                for i in 1:10, j in 1:5
+                    v = randn()
+                    if j ∈ [2, 3]
+                        @test ft(v, i, j) == ArviZStats._printf_with_sigdigits(v, sigdigits)
+                    else
+                        @test ft(v, i, j) === v
+                    end
+                    @test ft("foo", i, j) == "foo"
+                end
+            end
+        end
+    end
+
+    @testset "ft_printf_sigdigits_matching_se" begin
+        @testset "all columns" begin
+            @testset for scale in 1:3
+                se = rand(5)
+                ft = ArviZStats.ft_printf_sigdigits_matching_se(se; scale)
+                for i in eachindex(se), j in 1:5
+                    v = randn()
+                    sigdigits = ArviZStats.sigdigits_matching_se(v, se[i]; scale)
+                    @test ft(v, i, j) == ArviZStats._printf_with_sigdigits(v, sigdigits)
+                    @test ft("foo", i, j) == "foo"
+                end
+            end
+        end
+
+        @testset "subset of columns" begin
+            @testset for scale in 1:3
+                se = rand(5)
+                ft = ArviZStats.ft_printf_sigdigits_matching_se(se, [2, 3]; scale)
+                for i in eachindex(se), j in 1:5
+                    v = randn()
+                    if j ∈ [2, 3]
+                        sigdigits = ArviZStats.sigdigits_matching_se(v, se[i]; scale)
+                        @test ft(v, i, j) == ArviZStats._printf_with_sigdigits(v, sigdigits)
+                        @test ft("foo", i, j) == "foo"
+                    else
+                        @test ft(v, i, j) === v
+                    end
+                end
+            end
+        end
+    end
 end

--- a/test/ArviZStats/utils.jl
+++ b/test/ArviZStats/utils.jl
@@ -187,33 +187,6 @@ using StatsBase
         end
     end
 
-    @testset "sigdigits_matching_error" begin
-        @test ArviZStats.sigdigits_matching_error(123.456, 0.01) == 5
-        @test ArviZStats.sigdigits_matching_error(123.456, 1) == 3
-        @test ArviZStats.sigdigits_matching_error(123.456, 0.0001) == 7
-        @test ArviZStats.sigdigits_matching_error(1e5, 0.1) == 7
-        @test ArviZStats.sigdigits_matching_error(1e5, 0.2; scale=5) == 6
-        @test ArviZStats.sigdigits_matching_error(1e4, 0.5) == 5
-        @test ArviZStats.sigdigits_matching_error(1e4, 0.5; scale=1) == 6
-        @test ArviZStats.sigdigits_matching_error(1e5, 0.1; sigdigits_max=2) == 2
-
-        # errors
-        @test_throws ArgumentError ArviZStats.sigdigits_matching_error(123.456, -1)
-        @test_throws ArgumentError ArviZStats.sigdigits_matching_error(
-            123.456, 1; sigdigits_max=-1
-        )
-        @test_throws ArgumentError ArviZStats.sigdigits_matching_error(123.456, 1; scale=-1)
-
-        # edge cases
-        @test ArviZStats.sigdigits_matching_error(0.0, 1) == 0
-        @test ArviZStats.sigdigits_matching_error(NaN, 1) == 0
-        @test ArviZStats.sigdigits_matching_error(Inf, 1) == 0
-        @test ArviZStats.sigdigits_matching_error(100, 1; scale=Inf) == 0
-        @test ArviZStats.sigdigits_matching_error(100, Inf) == 0
-        @test ArviZStats.sigdigits_matching_error(100, 0) == 7
-        @test ArviZStats.sigdigits_matching_error(100, 0; sigdigits_max=2) == 2
-    end
-
     @testset "_assimilar" begin
         @testset for x in ([8, 2, 5], (8, 2, 5), (; a=8, b=2, c=5))
             @test @inferred(ArviZStats._assimilar((x=1.0, y=2.0, z=3.0), x)) ==
@@ -329,5 +302,32 @@ using StatsBase
             se_exp = std(log(mean(rand(n) * scale, w)) for _ in 1:ndraws)
             @test se ≈ se_exp rtol = 1e-1
         end
+    end
+
+    @testset "sigdigits_matching_se" begin
+        @test ArviZStats.sigdigits_matching_se(123.456, 0.01) == 5
+        @test ArviZStats.sigdigits_matching_se(123.456, 1) == 3
+        @test ArviZStats.sigdigits_matching_se(123.456, 0.0001) == 7
+        @test ArviZStats.sigdigits_matching_se(1e5, 0.1) == 7
+        @test ArviZStats.sigdigits_matching_se(1e5, 0.2; scale=5) == 6
+        @test ArviZStats.sigdigits_matching_se(1e4, 0.5) == 5
+        @test ArviZStats.sigdigits_matching_se(1e4, 0.5; scale=1) == 6
+        @test ArviZStats.sigdigits_matching_se(1e5, 0.1; sigdigits_max=2) == 2
+
+        # errors
+        @test_throws ArgumentError ArviZStats.sigdigits_matching_se(123.456, -1)
+        @test_throws ArgumentError ArviZStats.sigdigits_matching_se(
+            123.456, 1; sigdigits_max=-1
+        )
+        @test_throws ArgumentError ArviZStats.sigdigits_matching_se(123.456, 1; scale=-1)
+
+        # edge cases
+        @test ArviZStats.sigdigits_matching_se(0.0, 1) == 0
+        @test ArviZStats.sigdigits_matching_se(NaN, 1) == 0
+        @test ArviZStats.sigdigits_matching_se(Inf, 1) == 0
+        @test ArviZStats.sigdigits_matching_se(100, 1; scale=Inf) == 0
+        @test ArviZStats.sigdigits_matching_se(100, Inf) == 0
+        @test ArviZStats.sigdigits_matching_se(100, 0) == 7
+        @test ArviZStats.sigdigits_matching_se(100, 0; sigdigits_max=2) == 2
     end
 end

--- a/test/ArviZStats/waic.jl
+++ b/test/ArviZStats/waic.jl
@@ -102,9 +102,8 @@ include("helpers.jl")
         # regression test
         @test sprint(show, "text/plain", waic(idata)) == """
             WAICResult with estimates
-                   Estimate    SE
-             elpd       -31   1.4
-                p       0.9  0.33"""
+             elpd  elpd_mcse    p  p_mcse
+              -31        1.4  0.9    0.33"""
     end
     @testset "agrees with R waic" begin
         if r_loo_installed()


### PR DESCRIPTION
This PR adds a `StatsBase.summarystats` method for `Dataset` and `InferenceData` inputs (EDIT: and also new utilities for nicely showing tables)

Internally, this calls several stats and diagnostics functions on the entire input `Dataset` and then concatenates them along a newly created `:metric` dimension. This new `Dataset` may be returned, but by default, the `Dataset` is turned into an iterator over marginals, which is interpreted as a row table and reformatted to be a column table. This column table is lightly wrapped in a `SummaryStats` object, which implements the Tables interface. The benefits of this object over returning a `DataFrame` are:
- we can in principle dispatch on this object in the future
- we can intelligently choose the display precision, e.g. as with `ModelComparisonResult` and `AbstractELPDResult`, we use the MCSE of an estimate, if available, to choose the number of significant digits to show of the estimate itself.
- we can avoid the heavy DataFrames.jl dependency

EDIT: Because this PR adds a number of utilities for nicely showing tables, these are now used in the `show` methods of `ModelComparisonResult` and `AbstractELPDResult`. For the latter, I also reformatted the table to be more similar to that of `ModelComparisonResult`. Since changes to `show` methods should never be considered breaking changes, this applies here as well.

**Future improvements**

We can further support users providing their own stats funs to include/replace the ones used, but doing this well would involve adding a utility function for users to wrap a function that reduces to a scalar or a `Tuple` or  `NamedTuple` of scalars so that it maps across all non-sample indices for all variables, producing a new `Dataset`, optionally with a new dimension. This would actually reduce a lot of code redundancy, so this utility should appear in InferenceObjects first.

Similarly, the flattened iterator will be useful for plotting and may need to be refactored to become an API utility as well. This could certainly be done in a more type-stable way.

Without any additional work, we could use `Crayon`s to highlight bad ESS values and R-hat values. This would just require storing information about number of chains/draws in the `SummaryStats` object.