### PR TITLE
Rebuild documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 InferenceObjects = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"


### PR DESCRIPTION
The commit message for #297 contained `[no ci]`, so the docs for v0.10.0 did not build. This is a patch release with no change to supersede the docs that did not build.