### PR TITLE
Remove parsing of Stan-style indices in MCMCChains

### DIFF
--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  CMDSTAN_VERSION: "2.33.1"
+  CMDSTAN_VERSION: "2.34.1"
   CMDSTAN_PATH: "${{ GITHUB.WORKSPACE }}/.cmdstan/"
   JULIA_NUM_THREADS: 2
 
@@ -50,6 +50,6 @@ jobs:
         with:
           install-package: false
         env:
-          JULIA_CMDSTAN_HOME: ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}/ # required by CmdStan.jl
+          CMDSTAN: ${{ env.CMDSTAN_PATH }}/cmdstan-${{ env.CMDSTAN_VERSION }}/ # required by StanSample.jl
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.10.5"
+version = "0.11.0"
 
 [deps]
 InferenceObjects = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -27,7 +27,7 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
 AlgebraOfGraphics = "0.6.9"
-ArviZ = ">=0.10"
+ArviZ = "0.11.0"
 ArviZExampleData = "0.1.5"
 ArviZPythonPlots = "0.1"
 CairoMakie = "0.8.9, 0.9, 0.10, 0.11"

--- a/ext/ArviZMCMCChainsExt.jl
+++ b/ext/ArviZMCMCChainsExt.jl
@@ -8,7 +8,7 @@ else
     using ..MCMCChains: MCMCChains
 end
 
-const turing_key_map = Dict(
+const stats_key_map = Dict(
     :hamiltonian_energy => :energy,
     :hamiltonian_energy_error => :energy_error,
     :is_adapt => :tune,
@@ -16,16 +16,6 @@ const turing_key_map = Dict(
     :nom_step_size => :step_size_nom,
     :numerical_error => :diverging,
 )
-const stan_key_map = Dict(
-    :accept_stat__ => :acceptance_rate,
-    :divergent__ => :diverging,
-    :energy__ => :energy,
-    :lp__ => :lp,
-    :n_leapfrog__ => :n_steps,
-    :stepsize__ => :step_size,
-    :treedepth__ => :tree_depth,
-)
-const stats_key_map = merge(turing_key_map, stan_key_map)
 
 headtail(x) = x[1], x[2:end]
 

--- a/ext/ArviZMCMCChainsExt.jl
+++ b/ext/ArviZMCMCChainsExt.jl
@@ -30,13 +30,16 @@ const stats_key_map = merge(turing_key_map, stan_key_map)
 headtail(x) = x[1], x[2:end]
 
 function split_locname(name::AbstractString)
-    name = replace(name, r"[\[,]" => '.')
-    name = replace(name, ']' => "")
-    name, loc = headtail(split(name, '.'))
-    isempty(loc) && return name, ()
-    loc = tryparse.(Int, loc)
-    Nothing <: eltype(loc) && return name, ()
-    return name, tuple(loc...)
+    endswith(name, "]") || return name, ()
+    isplit = findlast(isequal('['), name)
+    isplit === nothing && return name, ()
+    try
+        loc = parse.(Int, split(name[(isplit + 1):(end - 1)], ','))
+        return name[1:(isplit - 1)], tuple(loc...)
+    catch e
+        e isa ArgumentError && return name, ()
+        rethrow(e)
+    end
 end
 function split_locname(name::Symbol)
     subname, loc = split_locname(string(name))

--- a/ext/ArviZMCMCChainsExt.jl
+++ b/ext/ArviZMCMCChainsExt.jl
@@ -17,8 +17,6 @@ const stats_key_map = Dict(
     :numerical_error => :diverging,
 )
 
-headtail(x) = x[1], x[2:end]
-
 function split_locname(name::AbstractString)
     endswith(name, "]") || return name, ()
     basename, index = rsplit(name[1:end-1], "["; limit=2)

--- a/ext/ArviZMCMCChainsExt.jl
+++ b/ext/ArviZMCMCChainsExt.jl
@@ -21,11 +21,11 @@ headtail(x) = x[1], x[2:end]
 
 function split_locname(name::AbstractString)
     endswith(name, "]") || return name, ()
-    isplit = findlast(isequal('['), name)
-    isplit === nothing && return name, ()
+    basename, index = rsplit(name[1:end-1], "["; limit=2)
+    isempty(index) && return name, ()
     try
-        loc = parse.(Int, split(name[(isplit + 1):(end - 1)], ','))
-        return name[1:(isplit - 1)], tuple(loc...)
+        loc = parse.(Int, split(index, ','))
+        return basename, tuple(loc...)
     catch e
         e isa ArgumentError && return name, ()
         rethrow(e)

--- a/test/ext/ArviZMCMCChainsExt/Project.toml
+++ b/test/ext/ArviZMCMCChainsExt/Project.toml
@@ -7,7 +7,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ArviZ = "0.10.3"
+ArviZ = "0.11.0"
 DimensionalData = "0.24, 0.25, 0.26"
 MCMCChains = "6"
 OrderedCollections = "1"

--- a/test/ext/ArviZMCMCChainsExt/runtests.jl
+++ b/test/ext/ArviZMCMCChainsExt/runtests.jl
@@ -92,9 +92,9 @@ end
     end
 
     @testset "dots are not split" begin
-        var_names = Symbol.(["a.b[1]", "a.b[2]", "a.c[2]", "a.c[1]"])
+        var_names = Symbol.(["a.b[1]", "a.b[2]", "a.θ[2]", "a.θ[1]"])
         coords = (dim=["x", "y"],)
-        dims = (var"a.b"=[:dim], var"a.c"=[:dim])
+        dims = (var"a.b"=[:dim], var"a.θ"=[:dim])
         nchains, ndraws = 4, 20
         chns = makechains(var_names, ndraws, nchains)
 
@@ -102,11 +102,11 @@ end
         ET = Base.promote_typeof(chns.name_map.parameters...)
 
         idata = from_mcmcchains(chns; coords, dims)
-        test_chains_data(chns, idata, :posterior, Symbol.(["a.b", "a.c"]); coords, dims)
+        test_chains_data(chns, idata, :posterior, Symbol.(["a.b", "a.θ"]); coords, dims)
         arr = idata.posterior.var"a.b"
         @test arr[:, :, 1] == chns.value[:, ET(var_names[1]), :]
         @test arr[:, :, 2] == chns.value[:, ET(var_names[2]), :]
-        arr = idata.posterior.var"a.c"
+        arr = idata.posterior.var"a.θ"
         @test arr[:, :, 2] == chns.value[:, ET(var_names[3]), :]
         @test arr[:, :, 1] == chns.value[:, ET(var_names[4]), :]
     end

--- a/test/ext/ArviZSampleChainsDynamicHMCExt/Project.toml
+++ b/test/ext/ArviZSampleChainsDynamicHMCExt/Project.toml
@@ -7,7 +7,7 @@ SampleChainsDynamicHMC = "6d9fd711-e8b2-4778-9c70-c1dfb499d4c4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ArviZ = "0.10.3"
+ArviZ = "0.11.0"
 DimensionalData = "0.24, 0.25, 0.26"
 Random = "1.6"
 SampleChains = "0.5"

--- a/test/ext/ArviZSampleChainsExt/Project.toml
+++ b/test/ext/ArviZSampleChainsExt/Project.toml
@@ -6,7 +6,7 @@ SampleChains = "754583d1-7fc4-4dab-93b5-5eaca5c9622e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ArviZ = "0.10.3"
+ArviZ = "0.11.0"
 DimensionalData = "0.24, 0.25, 0.26"
 Random = "1.6"
 SampleChains = "0.5"


### PR DESCRIPTION
This PR removes support for parsing variable names like `a.1.1` as an indexing statement `a[1,1]` when converting `MCMCChains.Chains` to `InferenceData`. This was previously only used by StanSample.jl, which supports many other output types including `InferenceData`. This allows statements like `a.b ~ Normal()` in Turing models to be parsed into variable names like `a.b`.

Relates #211 