### PR TITLE
Update README.md reference to CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Additional information can be found in the [Contributing Readme](https://github.
 ## Code of Conduct
 
 ArviZ wishes to maintain a positive community.
-Additional details can be found in the [Code of Conduct](https://github.com/arviz-devs/ArviZ.jl/blob/main/CODE_OF_CONDUCT.md).
+Additional details can be found in the [Code of Conduct](https://github.com/arviz-devs/ArviZ.jl?tab=coc-ov-file).
 
 ## Sponsors
 


### PR DESCRIPTION
I did not realize the link in the readme would stop working. I have updated it to the repository specific tab syntax so it shows it is part of the repo but renders the contents from the github org level file